### PR TITLE
[ch150122] Use the organization user's data while editing a user from organization settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ Development
 ### Bug fixes / enhancements
 - Guard code for vizjson users [#16267](https://github.com/CartoDB/cartodb/pull/16267)
 - Guard code for Users and Visualizations [#16265](https://github.com/CartoDB/cartodb/pull/16265)
+- Use the organization user's data while editing a user from organization settings [#16280](https://github.com/CartoDB/cartodb/pull/16280)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
 - Allow the usage of WMTS URLs with parameters to create custom basemaps [#16271](https://github.com/CartoDB/cartodb/pull/16271)

--- a/app/views/admin/organization_users/edit.html.erb
+++ b/app/views/admin/organization_users/edit.html.erb
@@ -3,11 +3,11 @@
 <% end %>
 <%= content_for(:js) do %>
   <script type="text/javascript">
-    var username = "<%= current_user.username %>";
+    var username = "<%= @user.username %>";
     var authenticity_token = "<%= form_authenticity_token %>";
     var config = <%= safe_js_object frontend_config %>;
-    var user_data = <%= safe_js_object current_user.data.to_json.html_safe %>;
-    var mobile_enabled = "<%= current_user.mobile_sdk_enabled? %>"
+    var user_data = <%= safe_js_object @user.data.to_json.html_safe %>;
+    var mobile_enabled = "<%= @user.mobile_sdk_enabled? %>"
   </script>
   <%= javascript_include_tag 'common', 'common_vendor', 'organization' %>
 <% end %>

--- a/app/views/admin/organization_users/edit.html.erb
+++ b/app/views/admin/organization_users/edit.html.erb
@@ -3,11 +3,11 @@
 <% end %>
 <%= content_for(:js) do %>
   <script type="text/javascript">
-    var username = "<%= @user.username %>";
+    var username = "<%= current_user.username %>";
     var authenticity_token = "<%= form_authenticity_token %>";
     var config = <%= safe_js_object frontend_config %>;
-    var user_data = <%= safe_js_object @user.data.to_json.html_safe %>;
-    var mobile_enabled = "<%= @user.mobile_sdk_enabled? %>"
+    var user_data = <%= safe_js_object current_user.data.to_json.html_safe %>;
+    var mobile_enabled = "<%= current_user.mobile_sdk_enabled? %>"
   </script>
   <%= javascript_include_tag 'common', 'common_vendor', 'organization' %>
 <% end %>

--- a/lib/assets/javascripts/dashboard/organization.js
+++ b/lib/assets/javascripts/dashboard/organization.js
@@ -93,6 +93,10 @@ $(function () {
 
     if (organization) {
       organizationUser.setOrganization(organization);
+      organizationUser.organization.set(
+        'available_quota_for_user',
+        window.organization_user_data.organization.available_quota_for_user
+      )
     }
   }
 

--- a/lib/assets/javascripts/dashboard/organization.js
+++ b/lib/assets/javascripts/dashboard/organization.js
@@ -96,7 +96,7 @@ $(function () {
       organizationUser.organization.set(
         'available_quota_for_user',
         window.organization_user_data.organization.available_quota_for_user
-      )
+      );
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.243",
+  "version": "1.0.0-assets.244-cgonzalez150122",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.244-cgonzalez150122",
+  "version": "1.0.0-assets.244",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.243",
+  "version": "1.0.0-assets.244-cgonzalez150122",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.244-cgonzalez150122",
+  "version": "1.0.0-assets.244",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/150122/sphera-unable-to-modify-organization-user-quota)

### Context

- The slider to update the organization users' quota from organizations settings is having a strange behavior: the total quota (assigned + available) is not reflecting the correct value after trying to update the assigned quota.
- The initial values in the view are correct, but the `available_quota_for_user` being used  by the JavaScript logic is the one from the organization's owner. This happens because the organization being set, this information should be the same for, but it isn't, because in [this code](https://github.com/CartoDB/cartodb/blob/master/app/models/user/user_decorator.rb#L160), the `available_quota_for_user` is being added to the organization information, and it is different for each user.

### Changes

- Overwrite the `available_quota_for_user` in the organization data using the value from the current organization user.