### PR TITLE
FIX: Oauth application redirection loop

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -288,16 +288,6 @@ class ApplicationController < ActionController::Base
     current_viewer ? Carto::AuthenticationManager.validate_session(warden, request, current_viewer) : not_authorized
   end
 
-  # login required only for users in this cloud
-  def login_required_cloud_user
-    session_username = session_usernames.first
-    user_in_cloud = Carto::User.exists?(username: session_username)
-
-    return true unless user_in_cloud
-
-    login_required_any_user
-  end
-
   def api_authorization_required
     authenticate!(:auth_api, :api_authentication, scope: CartoDB.extract_subdomain(request))
     Carto::AuthenticationManager.validate_session(warden, request, current_user)

--- a/app/controllers/carto/oauth_provider_controller.rb
+++ b/app/controllers/carto/oauth_provider_controller.rb
@@ -24,6 +24,8 @@ module Carto
 
     SILENT_PROMPT_VALUE = 'none'.freeze
 
+    UNAUTHORIZED_ERROR_MESSAGE = 'Unauthorized user'.freeze
+
     ssl_required
 
     layout 'frontend'
@@ -48,7 +50,7 @@ module Carto
     rescue_from OauthProvider::Errors::BaseError, with: :rescue_oauth_errors
 
     def consent
-      raise OauthProvider::Errors::AccessDenied.new if current_viewer.nil?
+      raise OauthProvider::Errors::AccessDenied.new(UNAUTHORIZED_ERROR_MESSAGE) if current_viewer.nil?
 
       return create_authorization_code if @oauth_app_user.try(:authorized?, @scopes)
       raise OauthProvider::Errors::AccessDenied.new if silent_flow?
@@ -62,7 +64,8 @@ module Carto
     end
 
     def authorize
-      raise OauthProvider::Errors::AccessDenied.new unless params[:accept] ||current_viewer.present?
+      raise OauthProvider::Errors::AccessDenied.new unless params[:accept]
+      raise OauthProvider::Errors::AccessDenied.new(UNAUTHORIZED_ERROR_MESSAGE) unless current_viewer.present?
 
       if @oauth_app_user
         @oauth_app_user.upgrade!(@scopes)


### PR DESCRIPTION
There is a redirection loop when the session user does not exist in the domain user's cloud so the request halted in the filter `:login_required_any_user` and it's redirected to the `/login` page. Due to the user is already logged it's redirected to the calling URL which is `/authorize` (Oauth controller) and the filter `:login_required_any_user` is executed again...

So in order to prevent this endless loop a new filter has been added called `:login_required_cloud_user` which only checks whether the user is logged for users in the cloud. By this way the request does not halt in the filter and it is able to reach the controller.

Some guard code was also added in the controller to raise a `OauthProvider::Errors::AccessDenied` error if the `current_viewer` is `nil`. This redirects the request to the OAuth application endpoint with an error:

```
https://some.oauth.app.endpoint?error=access_denied&error_description=Unauthorized%20user&state=eyJ0eXAiOiJK....
```

