### PR TITLE
Fix user migration export/import logs 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Development
 - Use the organization user's data while editing a user from organization settings [#16280](https://github.com/CartoDB/cartodb/pull/16280)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
+- Fix user migration export/import logs [#16298](https://github.com/CartoDB/cartodb/pull/16298)
 - Allow the usage of WMTS URLs with parameters to create custom basemaps [#16271](https://github.com/CartoDB/cartodb/pull/16271)
 - Sync license_type in redis with the values coming from Central [#16270](https://github.com/CartoDB/cartodb/pull/16270)
 - Add `do_bq_project` and `do_bq_dataset` to `api/v3/me` endpoint [#16276](https://github.com/CartoDB/cartodb/pull/16276)

--- a/app/models/carto/user_migration_export.rb
+++ b/app/models/carto/user_migration_export.rb
@@ -61,6 +61,7 @@ module Carto
 
       false
     ensure
+      log.store
       package.try(:cleanup)
     end
 

--- a/app/models/carto/user_migration_import.rb
+++ b/app/models/carto/user_migration_import.rb
@@ -51,6 +51,7 @@ module Carto
       update_attributes(state: STATE_FAILURE)
       false
     ensure
+      log.store
       package.try(:cleanup)
     end
 


### PR DESCRIPTION
### Context

- Logs for `UserMigrationExport` and `UserMigrationImport` are not being saved.

### Changes

- Always call `store` to save logs. 