### PR TITLE
[ch160203] OauthApps restricted by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Development
 - Guard code for Users and Visualizations [#16265](https://github.com/CartoDB/cartodb/pull/16265)
 - Use the organization user's data while editing a user from organization settings [#16280](https://github.com/CartoDB/cartodb/pull/16280)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
+- OauthApps restricted by default [#16304](https://github.com/CartoDB/cartodb/pull/16304)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
 - Fix user migration export/import logs [#16298](https://github.com/CartoDB/cartodb/pull/16298)
 - Allow the usage of WMTS URLs with parameters to create custom basemaps [#16271](https://github.com/CartoDB/cartodb/pull/16271)

--- a/app/models/carto/oauth_app.rb
+++ b/app/models/carto/oauth_app.rb
@@ -91,7 +91,7 @@ module Carto
 
     def restrict_app_to_organization_users
       self.restricted = true
-      self.oauth_app_organizations.new(
+      oauth_app_organizations.new(
         organization: user.organization,
         seats: user.organization.seats
       )

--- a/app/models/carto/oauth_app.rb
+++ b/app/models/carto/oauth_app.rb
@@ -24,7 +24,7 @@ module Carto
 
     before_validation :ensure_keys_generated
 
-    before_create :restrict_app_to_organization_users, if: ->(app) { app.user.organization_user? }
+    before_create :restrict_app_to_organization_users, if: ->(app) { app.user.try(:organization_user?) }
     after_create :create_central, if: :sync_with_central?
     after_update :update_central, if: :sync_with_central?
     after_destroy :delete_central, if: :sync_with_central?

--- a/spec/models/carto/oauth_app_spec.rb
+++ b/spec/models/carto/oauth_app_spec.rb
@@ -32,17 +32,16 @@ module Carto
       end
 
       describe 'restriction' do
-        before(:all) do
-          @organization_owner = create(:carto_user)
-          @organization = create(:organization, :with_owner, owner: @organization_owner)
-          @organization_owner.reload
+        let(:organization_owner) do
+          create(:organization, :with_owner, owner: @user)
+          @user.reload
         end
 
         it 'restrict the access to the user\'s organization if it exists' do
-          app = OauthApp.new(user: @organization_owner,
-                             name: 'name',
-                             redirect_uris: ['https://re.dir'],
-                             website_url: 'http://localhost')
+          app = described_class.new(user: organization_owner,
+                                    name: 'name',
+                                    redirect_uris: ['https://re.dir'],
+                                    website_url: 'http://localhost')
           expect(app).to(be_valid)
 
           app.save!
@@ -52,15 +51,15 @@ module Carto
 
           oauth_app_organization = app.oauth_app_organizations.take
 
-          expect(oauth_app_organization.organization_id).to eq(@organization_owner.organization_id)
-          expect(oauth_app_organization.seats).to eq(@organization_owner.organization.seats)
+          expect(oauth_app_organization.organization_id).to eq(organization_owner.organization_id)
+          expect(oauth_app_organization.seats).to eq(organization_owner.organization.seats)
         end
 
         it 'doesn\'t add restrictions if the user has no organization' do
-          app = OauthApp.new(user: @user,
-                             name: 'name',
-                             redirect_uris: ['https://re.dir'],
-                             website_url: 'http://localhost')
+          app = described_class.new(user: @user,
+                                    name: 'name',
+                                    redirect_uris: ['https://re.dir'],
+                                    website_url: 'http://localhost')
           expect(app).to(be_valid)
 
           app.save!

--- a/spec/models/carto/oauth_app_spec.rb
+++ b/spec/models/carto/oauth_app_spec.rb
@@ -31,6 +31,45 @@ module Carto
         expect(app.errors[:icon_url]).to(include("must be a valid URL"))
       end
 
+      describe 'restriction' do
+        before(:all) do
+          @organization_owner = create(:carto_user)
+          @organization = create(:organization, :with_owner, owner: @organization_owner)
+          @organization_owner.reload
+        end
+
+        it 'restrict the access to the user\'s organization if it exists' do
+          app = OauthApp.new(user: @organization_owner,
+                             name: 'name',
+                             redirect_uris: ['https://re.dir'],
+                             website_url: 'http://localhost')
+          expect(app).to(be_valid)
+
+          app.save!
+
+          expect(app.restricted).to(be_true)
+          expect(app.oauth_app_organizations).not_to(be_empty)
+
+          oauth_app_organization = app.oauth_app_organizations.take
+
+          expect(oauth_app_organization.organization_id).to eq(@organization_owner.organization_id)
+          expect(oauth_app_organization.seats).to eq(@organization_owner.organization.seats)
+        end
+
+        it 'doesn\'t add restrictions if the user has no organization' do
+          app = OauthApp.new(user: @user,
+                             name: 'name',
+                             redirect_uris: ['https://re.dir'],
+                             website_url: 'http://localhost')
+          expect(app).to(be_valid)
+
+          app.save!
+
+          expect(app.restricted).to(be_false)
+          expect(app.oauth_app_organizations).to(be_empty)
+        end
+      end
+
       describe 'redirection uri' do
         it 'rejects if empty' do
           app = OauthApp.new

--- a/spec/requests/carto/api/public/oauth_apps_controller_spec.rb
+++ b/spec/requests/carto/api/public/oauth_apps_controller_spec.rb
@@ -164,9 +164,6 @@ describe Carto::Api::Public::OauthAppsController do
       @app2 = create(:oauth_app, user_id: @carto_org_user_2.id, name: 'ABC', restricted: true)
       @app3 = create(:oauth_app, user_id: @carto_org_user_2.id)
 
-      @app1.oauth_app_organizations.create!(organization: @carto_organization, seats: 1)
-      @app2.oauth_app_organizations.create!(organization: @carto_organization, seats: 1)
-
       Carto::OauthAppUser.create!(user: @carto_org_user_1, oauth_app: @app1, scopes: ['user:profile'])
       Carto::OauthAppUser.create!(user: @carto_org_user_1, oauth_app: @app2)
     end
@@ -684,7 +681,6 @@ describe Carto::Api::Public::OauthAppsController do
   describe 'revoke' do
     before(:each) do
       @app = create(:oauth_app, user_id: @carto_org_user_2.id)
-      @app.oauth_app_organizations.create!(organization: @carto_organization, seats: 1)
       @oauth_app_user = Carto::OauthAppUser.create!(user: @carto_org_user_1, oauth_app: @app)
 
       @params = { id: @app.id, api_key: @carto_org_user_1.api_key }


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/160203/review-oauth-application-restriction-to-organization-users-only)

### Context

- OAuth apps should use the `restricted` attribute by default.

### Changes

- Set `restricted` to `true` for `Carto::OauthApp` by default for users with an organization.
- Create corresponding `Carto::OauthAppOrganization` for the user's organization.