### PR TITLE
[ch165944] Fix race condition when DO subscriptions are created

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ Development
 - OauthApps restricted by default [#16304](https://github.com/CartoDB/cartodb/pull/16304)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
 - Fix user migration export/import logs [#16298](https://github.com/CartoDB/cartodb/pull/16298)
+- Fix race condition when DO subscriptions are created [#16311](https://github.com/CartoDB/cartodb/pull/16311)
 - Allow the usage of WMTS URLs with parameters to create custom basemaps [#16271](https://github.com/CartoDB/cartodb/pull/16271)
 - Sync license_type in redis with the values coming from Central [#16270](https://github.com/CartoDB/cartodb/pull/16270)
 - Add `do_bq_project` and `do_bq_dataset` to `api/v3/me` endpoint [#16276](https://github.com/CartoDB/cartodb/pull/16276)

--- a/app/models/carto/helpers/user_commons.rb
+++ b/app/models/carto/helpers/user_commons.rb
@@ -290,11 +290,17 @@ module Carto::UserCommons
       license_srv.remove_from_redis(attributes[:do_dataset][:dataset_id])
     elsif attributes[:action] == 'add'
       license_srv.add_to_redis(attributes[:do_dataset])
+      create_do_sync!(attributes[:do_dataset][:dataset_id]) if attributes[:create_sync]
     else
       message = 'Error updating a DO subscription: unknown action'
       log_error(message: message)
       raise message
     end
+  end
+
+  def create_do_sync!(subscription_id)
+    Carto::DoSyncServiceFactory.get_for_user(self)
+                               .create_sync!(subscription_id, true)
   end
 
   def do_subscription(dataset_id)

--- a/lib/resque/do_sync_jobs.rb
+++ b/lib/resque/do_sync_jobs.rb
@@ -13,8 +13,11 @@ module Resque
         subscription_info = get_subscription_info(data_import)
 
         write_do_sync_status(subscription_info, data_import, licensing_service)
-        data_import.run_import!
-        write_do_sync_status(subscription_info, data_import, licensing_service)
+        begin
+          data_import.run_import!
+        ensure
+          write_do_sync_status(subscription_info, data_import, licensing_service)
+        end
       })
     end
 


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/165944/fix-race-condition-when-do-subscriptions-are-created)
- Related PR: https://github.com/CartoDB/cartodb-central/pull/3145

> **WARNING**: This PR should be deployed BEFORE the related PR

### Context

- There is a race condition when DO subscriptions are created in Central due to the following flow:
  - Publish a Pub/Sub message to add the subscription to Redis.
  - Make a POST request to create the synchronization in the cloud that fails if the subscription is not stored in Redis.
- When the POST request is executed before the message is consumed, a 404 error is raised, and the subscriptions gets stuck in `syncing` state forever.

### Changes

- Create synchronization when a DO subscription is created if the `create_sync` flag is present.
- Ensure that the subscription information is updated.