### PR TITLE
[ch89835] Migrate DO subscription information in inter-cloud migrations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ Development
 - Use the organization user's data while editing a user from organization settings [#16280](https://github.com/CartoDB/cartodb/pull/16280)
 - Fix schema name in layers created by free users [#16307](https://github.com/CartoDB/cartodb/pull/16307)
 - Limit start parameter of Dropbox connector [#16264](https://github.com/CartoDB/cartodb/pull/16264)
+- Migrate Redis DO subscription information in inter-cloud migrations [#16315](https://github.com/CartoDB/cartodb/pull/16315)
 - OauthApps restricted by default [#16304](https://github.com/CartoDB/cartodb/pull/16304)
 - Support staging hostname in the catalog [#16258](https://github.com/CartoDB/cartodb/pull/16258)
 - Fix user migration export/import logs [#16298](https://github.com/CartoDB/cartodb/pull/16298)

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -316,6 +316,13 @@ module Carto
         Carto::UserMetadataExportService.new.import_search_tweets_from_directory(user, "#{path}/user_#{user.id}")
       end
 
+      organization.users.each do |user|
+        Carto::UserMetadataExportService.new.import_redis_do_subscriptions(
+          user,
+          "#{path}/user_#{user.id}"
+        )
+      end
+
       organization
     end
   end

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -39,7 +39,10 @@ module Carto
     def restore_redis_do_subscriptions_from_json_export(exported_json_string, user)
       exported_hash = JSON.parse(exported_json_string).deep_symbolize_keys
       raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
-
+      Rollbar.info('Restore DO subscriptions', {
+        exported_hash: exported_hash,
+        do_subscriptions: exported_hash[:redis][:do_subscriptions]
+      })
       restore_do_subscriptions($users_metadata, exported_hash[:redis][:do_subscriptions], user)
     end
 
@@ -73,7 +76,11 @@ module Carto
     def restore_do_subscriptions(redis_db, redis_keys, user)
       redis_keys.each do |key, value|
         subscriptions = JSON.parse(value.presence || '[]')
-
+        Rollbar.info('Restore DO subscriptions - Key', {
+          key: key,
+          value: value,
+          subscriptions: subscriptions
+        })
         subscriptions.each do |sub|
           dataset = user.tables.find_by(name: sub['sync_table'])
           next if dataset.nil?

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -5,6 +5,7 @@ require 'json'
 # 1.0.1: add DO subscriptions
 module Carto
   module RedisExportServiceConfiguration
+
     CURRENT_VERSION = '1.0.1'.freeze
 
     def compatible_version?(version)
@@ -125,7 +126,7 @@ module Carto
       {
         users_metadata: export_dataservices("user:#{user.username}"),
         tables_metadata: export_named_maps(user),
-        do_subscriptions: export_do_subscriptions
+        do_subscriptions: export_do_subscriptions(user)
       }
     end
 
@@ -149,9 +150,12 @@ module Carto
 
     def export_do_subscriptions(user)
       do_subscriptions_key = "do:#{user.username}:datasets"
+      do_subscriptions =
+        $users_metadata.hget(do_subscriptions_key, Carto::DoLicensingService::PRESELECTED_STORAGE)
+      return {} if do_subscriptions.nil?
+
       {
-        do_subscriptions_key =>
-          $users_metadata.hget(redis_key, Carto::DoLicensingService::PRESELECTED_STORAGE)
+        do_subscriptions_key => do_subscriptions
       }
     end
 

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -39,10 +39,7 @@ module Carto
     def restore_redis_do_subscriptions_from_json_export(exported_json_string, user)
       exported_hash = JSON.parse(exported_json_string).deep_symbolize_keys
       raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
-      Rollbar.info('Restore DO subscriptions', {
-        exported_hash: exported_hash,
-        do_subscriptions: exported_hash[:redis][:do_subscriptions]
-      })
+
       restore_do_subscriptions($users_metadata, exported_hash[:redis][:do_subscriptions], user)
     end
 
@@ -76,11 +73,7 @@ module Carto
     def restore_do_subscriptions(redis_db, redis_keys, user)
       redis_keys.each do |key, value|
         subscriptions = JSON.parse(value.presence || '[]')
-        Rollbar.info('Restore DO subscriptions - Key', {
-          key: key,
-          value: value,
-          subscriptions: subscriptions
-        })
+
         subscriptions.each do |sub|
           dataset = user.tables.find_by(name: sub['sync_table'])
           next if dataset.nil?

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -2,9 +2,10 @@ require 'json'
 
 # Version History
 # 1.0.0: export organization metadata
+# 1.0.1: add DO subscriptions
 module Carto
   module RedisExportServiceConfiguration
-    CURRENT_VERSION = '1.0.0'.freeze
+    CURRENT_VERSION = '1.0.1'.freeze
 
     def compatible_version?(version)
       version.to_i == CURRENT_VERSION.split('.')[0].to_i
@@ -39,11 +40,13 @@ module Carto
     def restore_redis(redis_export)
       restore_keys($users_metadata, redis_export[:users_metadata])
       restore_named_maps($tables_metadata, redis_export[:tables_metadata])
+      restore_do_subscriptions($users_metadata, redis_export[:do_subscriptions])
     end
 
     def remove_redis(redis_export)
       remove_keys($users_metadata, redis_export[:users_metadata])
       remove_keys($tables_metadata, redis_export[:tables_metadata])
+      remove_keys($users_metadata, redis_export[:do_subscriptions])
     end
 
     def restore_keys(redis_db, redis_keys)
@@ -57,6 +60,22 @@ module Carto
         value.each do |name, named_map_config|
           redis_db.hset(key, name, Base64.decode64(named_map_config))
         end
+      end
+    end
+
+    def restore_do_subscriptions(redis_db, redis_keys)
+      redis_keys.each do |key, value|
+        subscriptions = JSON.parse(value.presence || '[]')
+
+        subscriptions.each do |sub|
+          dataset = user.tables.find_by(name: sub['sync_table'])
+          next if dataset.nil?
+
+          sub['sync_table_id'] = dataset.id
+          sub['synchronization_id'] = dataset.synchronization.try(:id)
+        end
+
+        redis_db.hset(key, Carto::DoLicensingService::PRESELECTED_STORAGE, subscriptions.to_json)
       end
     end
 
@@ -97,14 +116,16 @@ module Carto
     def export_organization(organization)
       {
         users_metadata: export_dataservices("org:#{organization.name}"),
-        tables_metadata: {}
+        tables_metadata: {},
+        do_subscriptions: {}
       }
     end
 
     def export_user(user)
       {
         users_metadata: export_dataservices("user:#{user.username}"),
-        tables_metadata: export_named_maps(user)
+        tables_metadata: export_named_maps(user),
+        do_subscriptions: export_do_subscriptions
       }
     end
 
@@ -124,6 +145,14 @@ module Carto
       end
       return {} unless named_maps_hash.any?
       { named_maps_key => named_maps_hash }
+    end
+
+    def export_do_subscriptions(user)
+      do_subscriptions_key = "do:#{user.username}:datasets"
+      {
+        do_subscriptions_key =>
+          $users_metadata.hget(redis_key, Carto::DoLicensingService::PRESELECTED_STORAGE)
+      }
     end
 
     def matches_user_visualization?(named_map, user)

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -16,18 +16,18 @@ module Carto
   module RedisExportServiceImporter
     include RedisExportServiceConfiguration
 
-    def restore_redis_from_json_export(exported_json_string, user = nil)
-      restore_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys, user)
+    def restore_redis_from_json_export(exported_json_string)
+      restore_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys)
     end
 
     def remove_redis_from_json_export(exported_json_string)
       remove_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys)
     end
 
-    def restore_redis_from_hash_export(exported_hash, user)
+    def restore_redis_from_hash_export(exported_hash)
       raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
 
-      restore_redis(exported_hash[:redis], user)
+      restore_redis(exported_hash[:redis])
     end
 
     def remove_redis_from_hash_export(exported_hash)
@@ -36,12 +36,18 @@ module Carto
       remove_redis(exported_hash[:redis])
     end
 
+    def restore_redis_do_subscriptions_from_json_export(exported_json_string, user)
+      exported_hash = JSON.parse(exported_json_string).deep_symbolize_keys
+      raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
+
+      restore_do_subscriptions($users_metadata, exported_hash[:redis][:do_subscriptions], user)
+    end
+
     private
 
-    def restore_redis(redis_export, user)
+    def restore_redis(redis_export)
       restore_keys($users_metadata, redis_export[:users_metadata])
       restore_named_maps($tables_metadata, redis_export[:tables_metadata])
-      restore_do_subscriptions($users_metadata, redis_export[:do_subscriptions], user)
     end
 
     def remove_redis(redis_export)

--- a/app/services/carto/redis_export_service.rb
+++ b/app/services/carto/redis_export_service.rb
@@ -16,18 +16,18 @@ module Carto
   module RedisExportServiceImporter
     include RedisExportServiceConfiguration
 
-    def restore_redis_from_json_export(exported_json_string)
-      restore_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys)
+    def restore_redis_from_json_export(exported_json_string, user = nil)
+      restore_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys, user)
     end
 
     def remove_redis_from_json_export(exported_json_string)
       remove_redis_from_hash_export(JSON.parse(exported_json_string).deep_symbolize_keys)
     end
 
-    def restore_redis_from_hash_export(exported_hash)
+    def restore_redis_from_hash_export(exported_hash, user)
       raise 'Wrong export version' unless compatible_version?(exported_hash[:version])
 
-      restore_redis(exported_hash[:redis])
+      restore_redis(exported_hash[:redis], user)
     end
 
     def remove_redis_from_hash_export(exported_hash)
@@ -38,10 +38,10 @@ module Carto
 
     private
 
-    def restore_redis(redis_export)
+    def restore_redis(redis_export, user)
       restore_keys($users_metadata, redis_export[:users_metadata])
       restore_named_maps($tables_metadata, redis_export[:tables_metadata])
-      restore_do_subscriptions($users_metadata, redis_export[:do_subscriptions])
+      restore_do_subscriptions($users_metadata, redis_export[:do_subscriptions], user)
     end
 
     def remove_redis(redis_export)
@@ -64,7 +64,7 @@ module Carto
       end
     end
 
-    def restore_do_subscriptions(redis_db, redis_keys)
+    def restore_do_subscriptions(redis_db, redis_keys, user)
       redis_keys.each do |key, value|
         subscriptions = JSON.parse(value.presence || '[]')
 

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -533,7 +533,7 @@ module Carto
       raise UserAlreadyExists.new if ::Carto::User.exists?(id: user.id)
       save_imported_user(user)
 
-      Carto::RedisExportService.new.restore_redis_from_json_export(redis_user_file(path))
+      Carto::RedisExportService.new.restore_redis_from_json_export(redis_user_file(path), user)
 
       user
     end

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -533,7 +533,7 @@ module Carto
       raise UserAlreadyExists.new if ::Carto::User.exists?(id: user.id)
       save_imported_user(user)
 
-      Carto::RedisExportService.new.restore_redis_from_json_export(redis_user_file(path), user)
+      Carto::RedisExportService.new.restore_redis_from_json_export(redis_user_file(path))
 
       user
     end
@@ -573,6 +573,11 @@ module Carto
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, meta_path)
 
       import_search_tweets_from_directory(user, meta_path)
+
+      Carto::RedisExportService.new.restore_redis_do_subscriptions_from_json_export(
+        redis_user_file(meta_path),
+        user
+      )
     end
 
     def import_search_tweets_from_directory(user, meta_path)

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -568,27 +568,26 @@ module Carto
     end
 
     def import_metadata_from_directory(user, meta_path)
-      Rollbar.info('Import metadata from directory', {
-        username: user.username
-      })
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_REMOTE, meta_path)
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_CANONICAL, meta_path)
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, meta_path)
 
       import_search_tweets_from_directory(user, meta_path)
-      Rollbar.info('Restore Redis DO subscriptions', {
-        redis_user_file: redis_user_file(meta_path)
-      })
-      Carto::RedisExportService.new.restore_redis_do_subscriptions_from_json_export(
-        redis_user_file(meta_path),
-        user
-      )
+
+      import_redis_do_subscriptions(user, meta_path)
     end
 
     def import_search_tweets_from_directory(user, meta_path)
       user_file = user_file_dir(meta_path)
       search_tweets = build_search_tweets_from_json_export(File.read(user_file))
       search_tweets.each { |st| save_imported_search_tweet(st, user) }
+    end
+
+    def import_redis_do_subscriptions(user, meta_path)
+      Carto::RedisExportService.new.restore_redis_do_subscriptions_from_json_export(
+        redis_user_file(meta_path),
+        user
+      )
     end
 
     private

--- a/app/services/carto/user_metadata_export_service.rb
+++ b/app/services/carto/user_metadata_export_service.rb
@@ -568,12 +568,17 @@ module Carto
     end
 
     def import_metadata_from_directory(user, meta_path)
+      Rollbar.info('Import metadata from directory', {
+        username: user.username
+      })
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_REMOTE, meta_path)
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_CANONICAL, meta_path)
       import_user_visualizations_from_directory(user, Carto::Visualization::TYPE_DERIVED, meta_path)
 
       import_search_tweets_from_directory(user, meta_path)
-
+      Rollbar.info('Restore Redis DO subscriptions', {
+        redis_user_file: redis_user_file(meta_path)
+      })
       Carto::RedisExportService.new.restore_redis_do_subscriptions_from_json_export(
         redis_user_file(meta_path),
         user

--- a/script/ci/cloudbuild-onprem-dev-tests.yaml
+++ b/script/ci/cloudbuild-onprem-dev-tests.yaml
@@ -365,7 +365,7 @@ steps:
         fi
   waitFor: ['upload-logs-onprem']
 
-timeout: 1800s
+timeout: 2100s
 options:
   machineType: 'E2_HIGHCPU_32'
 substitutions:

--- a/spec/services/carto/redis_export_service_spec.rb
+++ b/spec/services/carto/redis_export_service_spec.rb
@@ -87,7 +87,9 @@ describe Carto::RedisExportService do
   def check_do_subscriptions(export, synchronization)
     expect(export[:redis][:do_subscriptions].keys).to eq(["do:#{@user.username}:datasets"])
     expect(
-      JSON.parse(export[:redis][:do_subscriptions]["do:#{@user.username}:datasets"])['synchronization_id']
+      JSON.parse(
+        export[:redis][:do_subscriptions]["do:#{@user.username}:datasets"]
+      ).first['synchronization_id']
     ).to eq(synchronization.id)
   end
 


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/89835/inter-cloud-migrations-may-leave-redis-keys-behind)

### Context

- When a user is migrated from one cloud to another, we need to migrate the information about DO subscriptions stored in Redis.

### Changes

- [x] Export/import information stored in Redis about DO subscriptions.
- [x] Add tests