### PR TITLE
Don't check map quotas during dataset imports

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ Development
 - Fix broken links on the public footer [#16308](https://github.com/CartoDB/cartodb/pull/16308)
 - Fix search in _Filter by Column Value_ analysis [#16310](https://github.com/CartoDB/cartodb/pull/16310)
 - Use Google Maps provider if the base layer is Google [#16314](https://github.com/CartoDB/cartodb/pull/16314)
+- Allow importing datasets with exhausted map quota [#16320](https://github.com/CartoDB/cartodb/pull/16320)
 
 4.45.0 (2021-04-14)
 -------------------

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -60,29 +60,12 @@ module CartoDB
           @aborted = true
           results.each { |result| drop(result.table_name) }
         else
-          check_map_quotas(runner.visualizations)
           check_dataset_quotas(runner.visualizations)
           log('Proceeding to register')
           register_results(results)
           create_visualization if data_import.create_visualization
         end
         self
-      end
-
-      def check_map_quotas(visualizations)
-        log('Checking public and private map quota')
-        public_maps = visualizations.select do |v|
-          v.type == Carto::Visualization::TYPE_DERIVED && v.privacy != Carto::Visualization::PRIVACY_PRIVATE
-        end
-        private_maps = visualizations.select do |v|
-          v.type == Carto::Visualization::TYPE_DERIVED && v.privacy == Carto::Visualization::PRIVACY_PRIVATE
-        end
-        quota_checker = CartoDB::QuotaChecker.new(data_import.user)
-        return unless quota_checker.will_be_over_public_map_quota?(public_maps.count) ||
-                      quota_checker.will_be_over_private_map_quota?(private_maps.count)
-
-        log('Results would set map overquota')
-        raise CartoDB::Importer2::MapQuotaExceededError.new
       end
 
       def check_dataset_quotas(visualizations)

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -735,27 +735,5 @@ describe CartoDB::Connector::Importer do
       @user.public_dataset_quota = nil
       @user.save
     end
-
-    it 'fails to import a visualization export if private map quota is exceeded' do
-      filepath = "#{Rails.root}/services/importer/spec/fixtures/visualization_export_with_csv_table.carto"
-      @user.private_map_quota = 0
-      @user.save
-      @data_import = DataImport.create(
-        user_id: @user.id,
-        data_source: filepath,
-        updated_at: Time.now.utc,
-        append: false,
-        create_visualization: true
-      )
-      @data_import.values[:data_source] = filepath
-
-      expect { @data_import.run_import! }.to raise_error('Map quota exceeded')
-      @data_import.success.should eq false
-      @data_import.error_code.should eq 8007
-      Carto::User.any_instance.unstub(:public_map_quota)
-
-      @user.private_map_quota = nil
-      @user.save
-    end
   end
 end


### PR DESCRIPTION
# What?

This PR removes the map quota checks from the dataset imports. I believe if the map quota is exhausted but the user still has dataset quota remaining, we should allow data imports.

I've double checked in acceptance that:

- [x] With remaining dataset quota & exhausted map quota, dataset imports succeed
- [x] With exhausted map quota, you can't change the visibility of a map
- [x] With exhausted `public_map_quota`, you can't import a `.carto` file containing a public map
- [x] With exhausted `private_map_quota`, you can't import a `.carto` file containing a private map

The reason why I've removed that spec is that even the intention of it is OK: checking the `.carto` import fails without map quota, the implementation was not right because the test was failing but I checked this in acceptance and was working as expected.

Something worth mentioning is that when you upload a dataset, a default visualization of `table` type is created. With my change we're allowing to create this kind of visualizations even with the map quota is exhausted, but since this visualizations are created by default and are not visible by the user in the UI, I think it was more important to allow the user uploading datasets rather than forbidding it just because some internal stuff we do collides with this approach.