### PR TITLE
[ch174348] Render tileset viewer features in front of basemap

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@ Development
 - Avoid updating analysis nodes more than once when moving layers in Builder [#16279](https://github.com/CartoDB/cartodb/pull/16279)
 - Fix subscription/sample filter for datasets [#16254](https://github.com/CartoDB/cartodb/pull/16254)
 - Use fully qualified table name while creating a new map from a shared dataset [#16241](https://github.com/CartoDB/cartodb/pull/16241)
+- Render tileset viewer features in front of basemap [#16333](https://github.com/CartoDB/cartodb/pull/16333)
 - Add new events for DO full access [#16290](https://github.com/CartoDB/cartodb/pull/16290)
 - Bump Rubocop to v1.12.1 to fix the CI hook [#16305](https://github.com/CartoDB/cartodb/pull/16305)
 - Fix an issue that prevents API OPTIONS from succeeding because of undue CSRF check [#16292](https://github.com/CartoDB/cartodb/pull/16292)

--- a/lib/assets/javascripts/new-dashboard/styles/main.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/main.scss
@@ -34,8 +34,4 @@
 
 //vendors
 @import 'vendors/perfect-scrollbar';
-
-// NOTE: Forcing canvas depth, since the 'deckgl-overlay' ID is not being applied to the viewer
-#deckgl-wrapper > canvas {
-  z-index: 1;
-}
+@import 'vendors/deckgl';

--- a/lib/assets/javascripts/new-dashboard/styles/main.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/main.scss
@@ -34,3 +34,8 @@
 
 //vendors
 @import 'vendors/perfect-scrollbar';
+
+// NOTE: Forcing canvas depth, since the 'deckgl-overlay' ID is not being applied to the viewer
+#deckgl-wrapper > canvas {
+  z-index: 1;
+}

--- a/lib/assets/javascripts/new-dashboard/styles/vendors/_deckgl.scss
+++ b/lib/assets/javascripts/new-dashboard/styles/vendors/_deckgl.scss
@@ -1,0 +1,4 @@
+// NOTE: Forcing canvas depth, since the 'deckgl-overlay' ID is not being applied to the tileset viewer
+#deckgl-wrapper > canvas {
+  z-index: 1;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.0",
+  "version": "1.0.0-assets.258",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.257",
+  "version": "1.0.0-assets.258",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/174348/zwade-spatial-extension-map-viewer-not-rendering-features)

### Context

- After https://github.com/CartoDB/cartodb/pull/16325, the `deckgl-overlay` ID disappeared from the Deck.gl canvas that contains the features in the tileset viewer. The consequences are that this style https://github.com/CartoDB/viewer/blob/master/src/App.css#L9 is not being applied, and the canvas is being rendered behind the basemap.

### Changes

- Add a patch to add the required `z-index` value to the canvas (even if the `deckgl-overlay` ID is not assigned).

### Staging acceptance

![Screenshot from 2021-08-18 11-58-45](https://user-images.githubusercontent.com/6042873/129886827-82e6829f-9271-40a7-bed0-209ceb2042ef.png)
