### PR TITLE
Fix cloudbuild in onprem-tests

### DIFF
--- a/script/ci/cloudbuild-onprem-dev-tests.yaml
+++ b/script/ci/cloudbuild-onprem-dev-tests.yaml
@@ -278,6 +278,8 @@ steps:
   entrypoint: /bin/sh
   dir: /workspace/dockerize-onpremises
   args: ['ci/init.sh']
+  env: &onprem-vars
+    - 'COMPOSE_FILE=docker-compose.yml:ci/docker-compose.ci.yml'
   waitFor: ['copy-onprem-files']
 
 # Install license
@@ -285,6 +287,7 @@ steps:
   id: license-onprem
   entrypoint: /bin/bash
   dir: /workspace/dockerize-onpremises
+  env: *onprem-vars
   args: 
     - -cex
     - |
@@ -297,6 +300,7 @@ steps:
   id: test-onprem
   entrypoint: /bin/bash
   dir: /workspace/dockerize-onpremises
+  env: *onprem-vars
   args: 
       - -cx
       - |
@@ -318,10 +322,11 @@ steps:
   id: logs-onprem
   entrypoint: /bin/sh
   dir: /workspace/dockerize-onpremises
+  env: *onprem-vars
   args:
     - -c
     - |
-      docker-compose -f docker-compose.yml -f ci/docker-compose.ci.yml logs --no-color > onprem_docker_compose_logs
+      COMPOSE_FILE=$${COMPOSE_FILE} docker-compose logs --no-color > onprem_docker_compose_logs
       echo "Logs will be available during 14 days at gs://${_REPO}-ci-tmp-logs/test_logs_${BUILD_ID}/"
   waitFor: ['test-onprem']
 


### PR DESCRIPTION
**Related with**:
- https://github.com/CartoDB/dockerize-onpremises/pull/77
- https://app.clubhouse.io/cartoteam/story/174531/hctx-dev-admin-docker-on-prem-fails-to-run-due-to-google-permissions