### PR TITLE
[ch174348] Render tileset viewer features in front of basemap v2

### DIFF
--- a/lib/assets/javascripts/tilesets-viewer/main.scss
+++ b/lib/assets/javascripts/tilesets-viewer/main.scss
@@ -38,3 +38,4 @@ $color-primary--dark: #3D33CC;
 
 //vendors
 @import '../new-dashboard/styles/vendors/perfect-scrollbar';
+@import '../new-dashboard/styles/vendors/deckgl';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.258",
+  "version": "1.0.0-assets.259",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.258",
+  "version": "1.0.0-assets.259",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/174348/zwade-spatial-extension-map-viewer-not-rendering-features)
- [Previous PR](https://github.com/CartoDB/cartodb/pull/16333)

### Changes

- Adding `z-index` also to the style being used by the `/viewer/user/...` path.