### PR TITLE
Use different model to regenerate org's api keys

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ Development
 - Add setting to disable diagnosis page [#16324](https://github.com/CartoDB/cartodb/pull/16324)
 - Fix wrong layer schema when creating a map from a shared dataset [#16323](https://github.com/CartoDB/cartodb/pull/16323)
 - Fix auto guessing when a csv field is wrong [#16326](https://github.com/CartoDB/cartodb/pull/16326)
+- Fix regenerating API Keys for a whole organization [#16336](https://github.com/CartoDB/cartodb/pull/16336)
 
 4.45.0 (2021-04-14)
 -------------------

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -131,7 +131,7 @@ class Admin::OrganizationsController < Admin::AdminController
 
   def regenerate_all_api_keys
     valid_password_confirmation
-    @organization.users.each(&:regenerate_all_api_keys)
+    @organization.users.map(&:sequel_user).each(&:regenerate_all_api_keys)
 
     redirect_to CartoDB.url(self, 'organization_settings', user: current_user),
                 flash: { success: "Users API keys regenerated successfully" }


### PR DESCRIPTION
## Resources
[Clubhouse story](https://app.clubhouse.io/cartoteam/story/175217/regenerate-all-api-keys-issue)

## Context
When an organization's admin tries to regenerate the API Keys of all the org's users, there is a bug that breaks the keys.

## Changes
- [x] Regenerate the organization's API Keys using the right model.