### PR TITLE
[ch174222] Add username/email validation when a organization user is created

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ Development
 - Use fully qualified table name while creating a new map from a shared dataset [#16241](https://github.com/CartoDB/cartodb/pull/16241)
 - Render tileset viewer features in front of basemap [#16333](https://github.com/CartoDB/cartodb/pull/16333)
 - Add new events for DO full access [#16290](https://github.com/CartoDB/cartodb/pull/16290)
+- Add username/email validation when a organization user is created [#16341](https://github.com/CartoDB/cartodb/pull/16341)
 - Bump Rubocop to v1.12.1 to fix the CI hook [#16305](https://github.com/CartoDB/cartodb/pull/16305)
 - Fix an issue that prevents API OPTIONS from succeeding because of undue CSRF check [#16292](https://github.com/CartoDB/cartodb/pull/16292)
 - Fix a regression test and add some warnings to source code [#16297](https://github.com/CartoDB/cartodb/pull/16297)

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -84,9 +84,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
 
     if Cartodb::Central.api_sync_enabled?
       response = central_new_organization_user_validation(@user)
-      if !response['valid']
-        raise Sequel::ValidationFailed.new("Validation failed: #{response['error']}")
-      end
+      raise Sequel::ValidationFailed, "Validation failed: #{response['error']}" unless response['valid']
     end
 
     @user.save(raise_on_failure: true)

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -82,6 +82,13 @@ class Admin::OrganizationUsersController < Admin::AdminController
     end
     raise Carto::UnprocesableEntityError.new("Soft limits validation error") if validation_failure
 
+    if Cartodb::Central.api_sync_enabled?
+      response = central_new_organization_user_validation(@user)
+      unless response['valid']
+        raise Sequel::ValidationFailed.new("Validation failed: #{response['error']}")
+      end
+    end
+
     @user.save(raise_on_failure: true)
     @user.create_in_central
     common_data_url = CartoDB::Visualization::CommonDataService.build_url(self)

--- a/app/controllers/admin/organization_users_controller.rb
+++ b/app/controllers/admin/organization_users_controller.rb
@@ -84,7 +84,7 @@ class Admin::OrganizationUsersController < Admin::AdminController
 
     if Cartodb::Central.api_sync_enabled?
       response = central_new_organization_user_validation(@user)
-      unless response['valid']
+      if !response['valid']
         raise Sequel::ValidationFailed.new("Validation failed: #{response['error']}")
       end
     end

--- a/app/helpers/organization_users_helper.rb
+++ b/app/helpers/organization_users_helper.rb
@@ -50,6 +50,10 @@ module OrganizationUsersHelper
     hardened_params.symbolize_keys
   end
 
+  def central_new_organization_user_validation(user)
+    Cartodb::Central.new.validate_new_organization_user(username: user.username, email: user.email)
+  end
+
   # This is not run at model validation flow because we might want to override this rules.
   # owner parameter allows validation before actual value setting
   def soft_limits_validation(user, params_to_update, owner = user.organization.owner)

--- a/lib/cartodb/central.rb
+++ b/lib/cartodb/central.rb
@@ -24,10 +24,8 @@ module Cartodb
       !api_sync_enabled?
     end
 
-    class <<self
-
+    class << self
       alias login_redirection_enabled? api_sync_enabled?
-
     end
 
     def initialize
@@ -91,6 +89,15 @@ module Cartodb
 
     def get_organization_user(organization_name, username)
       send_request("api/organizations/#{ organization_name }/users/#{ username }", nil, :get, [200])
+    end
+
+    def validate_new_organization_user(username:, email:)
+      send_request(
+        'api/organizations/users/validate_new',
+        { user: { username: username, email: email } },
+        :post,
+        [200, 400]
+      )
     end
 
     def create_organization_user(organization_name, user_attributes)


### PR DESCRIPTION
### Resources

- [Clubhouse story](https://app.clubhouse.io/cartoteam/story/174222/review-checks-when-a-new-user-is-created-from-cloud)
- [Related PR](https://github.com/CartoDB/cartodb-central/pull/3152)

### Context

- Sometimes, organization users are created in the cloud without errors, but an error is raised when the user is being created in Central due to the `username` or the `email` already exists (in another cloud, or a user not provisioned yet).
- Regarding security: the endpoint is using basic HTTP authentication, so it can't be used to exploit information about usernames/emails available.
- Regarding Onprem: we are skipping the validation if the sync communication with Central is not properly configured.

### Changes

- Add new validation, checking with Central if the provided username/email is not taken, when a new organization user is created.
