### PR TITLE
[sc182549] Fix data overwrite when a user is promoted to admin

### DIFF
--- a/app/models/user/user_organization.rb
+++ b/app/models/user/user_organization.rb
@@ -22,6 +22,7 @@ module CartoDB
     def promote_user_to_admin
       raise "Organization is already active. You can't assign an admin" if @active
       @owner.organization_id = @organization.id
+      @owner.this.update organization_id: @organization.id
       @owner.db_service.move_to_own_schema
       @organization.owner_id = @owner.id
       @organization.admin_email = @owner.email
@@ -32,7 +33,6 @@ module CartoDB
       @owner.db_service.reset_user_schema_permissions
 
       @owner.db_service.setup_organization_user_schema
-      @owner.save
       @owner.db_service.monitor_user_notification
       @active = true
     end


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/182549/lightbox-admin-account-inaccessible-due-to-404-error)

### Context

- We are changing the way the user information is updated to not overwrite other user data assigned asynchronously by other PubSub message. More context in .

### Changes

- Replace the `save` by a single `update`, since `organization_id` is the only parameter being updated in that flow.