### PR TITLE
Add SAML random usernames choice

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Development
 * Upgrade to CARTO Viewer v1.0.8 [16347](https://github.com/CartoDB/cartodb/pull/16347)
 * Show user's database location in profile [16349](https://github.com/CartoDB/cartodb/pull/16349)
 * Setting to enable/disable import notifications [16354](https://github.com/CartoDB/cartodb/pull/16354)
+* Setting to enable/disable random username generation on SAML authentication process [16372](https://github.com/CartoDB/cartodb/pull/16372)
 
 ### Bug fixes / enhancements
 - Add marginTop to Page when notification is displayed [#16355](https://github.com/CartoDB/cartodb/pull/16355)

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -159,6 +159,7 @@ class Admin::OrganizationsController < Admin::AdminController
     @organization.auth_github_enabled = attributes[:auth_github_enabled]
     @organization.strong_passwords_enabled = attributes[:strong_passwords_enabled]
     @organization.password_expiration_in_d = attributes[:password_expiration_in_d]
+    @organization.random_saml_username = attributes[:random_saml_username]
     @organization.update_in_central
     @organization.save(raise_on_failure: true)
 

--- a/app/controllers/carto/api/organization_presenter.rb
+++ b/app/controllers/carto/api/organization_presenter.rb
@@ -35,8 +35,8 @@ module Carto
           mapzen_routing_block_price: @organization.mapzen_routing_block_price,
           geocoder_provider:          @organization.geocoder_provider,
           isolines_provider:          @organization.isolines_provider,
-          routing_provider: @organization.routing_provider,
-          map_views_quota: @organization.map_views_quota,
+          routing_provider:           @organization.routing_provider,
+          map_views_quota:            @organization.map_views_quota,
           twitter_datasource_quota:   @organization.twitter_datasource_quota,
           map_view_block_price:       @organization.map_view_block_price,
           geocoding_block_price:      @organization.geocoding_block_price,
@@ -49,7 +49,8 @@ module Carto
           admin_email:                @organization.admin_email,
           avatar_url:                 @organization.avatar_url,
           user_count:                 @organization.users.count,
-          password_expiration_in_d:   @organization.password_expiration_in_d
+          password_expiration_in_d:   @organization.password_expiration_in_d,
+          random_saml_username:       @organization.random_saml_username
         }
       end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -186,10 +186,17 @@ class SessionsController < ApplicationController
       return
     end
 
-    saml_email = warden.env['warden.options'][:saml_email]
-    username = CartoDB::UserAccountCreator.email_to_username(saml_email)
-    unique_username = Carto::UsernameProposer.find_unique(username)
     organization_id = warden.env['warden.options'][:organization_id]
+    organization = Carto::Organization.find(organization_id)
+    saml_email = warden.env['warden.options'][:saml_email]
+
+    if organization.random_saml_username
+      username = CartoDB::UserAccountCreator.random_saml_username
+    else
+      username = CartoDB::UserAccountCreator.email_to_username(saml_email)
+    end
+
+    unique_username = Carto::UsernameProposer.find_unique(username)
 
     create_user(
       username: unique_username,

--- a/app/models/concerns/cartodb_central_synchronizable.rb
+++ b/app/models/concerns/cartodb_central_synchronizable.rb
@@ -84,7 +84,7 @@ module CartodbCentralSynchronizable
            salesforce_datasource_enabled geocoder_provider
            isolines_provider routing_provider engine_enabled builder_enabled
            mapzen_routing_quota mapzen_routing_block_price no_map_logo auth_github_enabled
-           password_expiration_in_d inherit_owner_ffs)
+           password_expiration_in_d inherit_owner_ffs random_saml_username)
       when :update
         %i(seats viewer_seats quota_in_bytes display_name description website
            discus_shortname twitter_username geocoding_quota map_views_quota
@@ -96,7 +96,7 @@ module CartodbCentralSynchronizable
            salesforce_datasource_enabled geocoder_provider
            isolines_provider routing_provider engine_enabled builder_enabled
            mapzen_routing_quota mapzen_routing_block_price no_map_logo auth_github_enabled
-           password_expiration_in_d inherit_owner_ffs)
+           password_expiration_in_d inherit_owner_ffs random_saml_username)
       end
     elsif user?
       %i(account_type admin org_admin crypted_password database_host
@@ -129,7 +129,7 @@ module CartodbCentralSynchronizable
       when :update
         allowed_attributes = %i(seats viewer_seats display_name description website discus_shortname twitter_username
                                 auth_username_password_enabled auth_google_enabled password_expiration_in_d
-                                inherit_owner_ffs)
+                                inherit_owner_ffs random_saml_username)
         attributes.symbolize_keys.slice(*allowed_attributes).merge(name: name)
       end
     elsif user?

--- a/app/presenters/organization_presenter.rb
+++ b/app/presenters/organization_presenter.rb
@@ -52,7 +52,8 @@ class OrganizationPresenter < BasePresenter
       twitter_username: twitter_username,
       seats: seats,
       avatar_url: avatar_url,
-      password_expiration_in_d: password_expiration_in_d
+      password_expiration_in_d: password_expiration_in_d,
+      random_saml_username: random_saml_username
     }
   end
 

--- a/app/services/carto/organization_metadata_export_service.rb
+++ b/app/services/carto/organization_metadata_export_service.rb
@@ -24,7 +24,7 @@ module Carto
       :auth_google_enabled, :location, :here_isolines_quota, :here_isolines_block_price, :strong_passwords_enabled,
       :salesforce_datasource_enabled, :viewer_seats, :geocoder_provider, :isolines_provider, :routing_provider,
       :auth_github_enabled, :engine_enabled, :mapzen_routing_quota, :mapzen_routing_block_price, :builder_enabled,
-      :auth_saml_configuration, :no_map_logo, :password_expiration_in_d, :inherit_owner_ffs
+      :auth_saml_configuration, :no_map_logo, :password_expiration_in_d, :inherit_owner_ffs, :random_saml_username
     ].freeze
 
     def compatible_version?(version)

--- a/app/views/admin/organizations/auth.html.erb
+++ b/app/views/admin/organizations/auth.html.erb
@@ -88,6 +88,21 @@
 
         <div class="FormAccount-row">
           <div class="FormAccount-rowLabel">
+            <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">Random SAML Usernames</label>
+          </div>
+          <div class="FormAccount-rowData">
+            <div class="Toggler">
+              <%= f.check_box :random_saml_username, :id => "random_saml_username" %>
+              <%= label_tag(:random_saml_username, '') %>
+            </div>
+            <div class="u-flex u-lSpace--xl">
+              <p class="CDB-Text CDB-Size-small u-altTextColor">Generate random usernames for new SAML users.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="FormAccount-row">
+          <div class="FormAccount-rowLabel">
             <label class="CDB-Text CDB-Size-medium is-semibold u-mainTextColor">Password Expiration</label>
           </div>
 

--- a/db/migrate/20211110171603_add_random_username_saml_feature_flag.rb
+++ b/db/migrate/20211110171603_add_random_username_saml_feature_flag.rb
@@ -1,0 +1,12 @@
+require 'carto/db/migration_helper'
+
+include Carto::Db::MigrationHelper
+
+migration(
+  Proc.new do
+    add_column :organizations, :random_saml_username, :bool, default: false
+  end,
+  Proc.new do
+    drop_column :organizations, :random_saml_username
+  end
+)

--- a/lib/assets/javascripts/new-dashboard/components/NavigationBar/UserDropdown.vue
+++ b/lib/assets/javascripts/new-dashboard/components/NavigationBar/UserDropdown.vue
@@ -17,8 +17,8 @@
           <img :src="userModel.avatar_url">
         </div>
         <div class="navbar-dropdown-userInfo">
-          <p class="text is-semibold is-caption">{{userModel.username}}</p>
-          <p class="text is-small">{{userModel.email}}</p>
+          <p class="text is-semibold is-caption">{{userModel.organization.random_saml_username ? userModel.email : userModel.username}}</p>
+          <p v-if="!userModel.organization.random_saml_username" class="text is-small">{{userModel.email}}</p>
         </div>
       </li>
       <li class="navbar-dropdown-iconLink">

--- a/lib/assets/javascripts/new-dashboard/components/NavigationBar/UserDropdown.vue
+++ b/lib/assets/javascripts/new-dashboard/components/NavigationBar/UserDropdown.vue
@@ -17,8 +17,8 @@
           <img :src="userModel.avatar_url">
         </div>
         <div class="navbar-dropdown-userInfo">
-          <p class="text is-semibold is-caption">{{userModel?.organization?.random_saml_username ? userModel.email : userModel.username}}</p>
-          <p v-if="!userModel?.organization?.random_saml_username" class="text is-small">{{userModel.email}}</p>
+          <p class="text is-semibold is-caption">{{(userModel.organization || {}).random_saml_username ? userModel.email : userModel.username}}</p>
+          <p v-if="!(userModel.organization || {}).random_saml_username" class="text is-small">{{userModel.email}}</p>
         </div>
       </li>
       <li class="navbar-dropdown-iconLink">

--- a/lib/assets/javascripts/new-dashboard/components/NavigationBar/UserDropdown.vue
+++ b/lib/assets/javascripts/new-dashboard/components/NavigationBar/UserDropdown.vue
@@ -17,8 +17,8 @@
           <img :src="userModel.avatar_url">
         </div>
         <div class="navbar-dropdown-userInfo">
-          <p class="text is-semibold is-caption">{{userModel.organization.random_saml_username ? userModel.email : userModel.username}}</p>
-          <p v-if="!userModel.organization.random_saml_username" class="text is-small">{{userModel.email}}</p>
+          <p class="text is-semibold is-caption">{{userModel?.organization?.random_saml_username ? userModel.email : userModel.username}}</p>
+          <p v-if="!userModel?.organization?.random_saml_username" class="text is-small">{{userModel.email}}</p>
         </div>
       </li>
       <li class="navbar-dropdown-iconLink">

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/Welcome.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="welcome-section">
     <WelcomeFirst v-if="isFirst" :name="name" :userType="userType"></WelcomeFirst>
-    <WelcomeCompact v-else :name="name" :userType="userType" @newDatesetClicked="onNewDatesetClicked" @newMapClicked="onNewMapClicked">
+    <WelcomeCompact v-else :name="name" :organization="organization" :userType="userType" @newDatesetClicked="onNewDatesetClicked" @newMapClicked="onNewMapClicked">
       <template>
         <a v-if="showUpgrade" :href="accountUpgradeURL" class="button is-primary">
           {{ $t('HomePage.WelcomeSection.upgradeNow') }}

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/WelcomeCompact.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/WelcomeCompact.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="welcome-compact">
     <div class="container welcome-compact__content">
-      <div class="welcome-compact__greeting title is-caption">{{ greeting }}</div>
+      <div v-if="!randomSAMLUsernames" class="welcome-compact__greeting title is-caption">{{ greeting }}</div>
       <div class="welcome-compact__actions">
         <OnboardingButton :isFirstTimeViewingDashboard="false"></OnboardingButton>
         <button @click="onNewMapClicked" class="button is-primary button--ghost" :disabled="!canCreateMaps">{{ $t(`HomePage.WelcomeSection.actions.createMap`) }}</button>
@@ -26,7 +26,8 @@ export default {
     OnboardingButton
   },
   props: {
-    name: String
+    name: String,
+    organization: Object
   },
   computed: {
     greeting () {
@@ -37,6 +38,9 @@ export default {
     },
     canCreateMaps () {
       return this.$store.getters['user/canCreateMaps'];
+    },
+    randomSAMLUsernames () {
+      return this.$props.organization.random_saml_username;
     }
   },
   methods: {

--- a/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/WelcomeCompact.vue
+++ b/lib/assets/javascripts/new-dashboard/pages/Home/WelcomeSection/WelcomeCompact.vue
@@ -40,7 +40,7 @@ export default {
       return this.$store.getters['user/canCreateMaps'];
     },
     randomSAMLUsernames () {
-      return this.$props.organization.random_saml_username;
+      return (this.$props.organization || {}).random_saml_username;
     }
   },
   methods: {

--- a/lib/user_account_creator.rb
+++ b/lib/user_account_creator.rb
@@ -108,7 +108,7 @@ module CartoDB
       email.strip.split('@')[0].gsub(/[^A-Za-z0-9-]/, '-').downcase
     end
 
-    def random_saml_username
+    def self.random_saml_username
       SecureRandom.hex
     end
 

--- a/lib/user_account_creator.rb
+++ b/lib/user_account_creator.rb
@@ -108,6 +108,10 @@ module CartoDB
       email.strip.split('@')[0].gsub(/[^A-Za-z0-9-]/, '-').downcase
     end
 
+    def random_saml_username
+      SecureRandom.hex
+    end
+
     def user
       @user
     end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.277",
+  "version": "1.0.0-assets.278",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.277",
+  "version": "1.0.0-assets.278",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/spec/services/carto/organization_metadata_export_service_spec.rb
+++ b/spec/services/carto/organization_metadata_export_service_spec.rb
@@ -367,6 +367,7 @@ describe Carto::OrganizationMetadataExportService do
         mapzen_routing_block_price: nil,
         builder_enabled: true,
         auth_saml_configuration: {},
+        random_saml_username: false,
         no_map_logo: false,
         password_expiration_in_d: 365,
         inherit_owner_ffs: false,


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/191984/create-users-with-random-username-when-first-login-through-saml)

### Context

- There is an organization exposing personal information from their employees after signing up through the SAML process. They would like to generate random usernames through this process.

### Changes

- Add a new property to the Organization model in order to manage the random generation of usernames through SAML authentication.