### PR TITLE
[sc192476] Increase import limit of datasets from a single file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Development
 - Disable email validation in DO Premium Subscriptions [#16309](https://github.com/CartoDB/cartodb/pull/16309)
 - Hide sharing tab from viewer in on-premises [#16299](https://github.com/CartoDB/cartodb/pull/16299)
 - Remove all references to Spatial Data Catalog and Kepler GL maps in on-premises [#16293](https://github.com/CartoDB/cartodb/pull/16293)
+- Increase hard-limit of MAX_TABLES_PER_IMPORT [#16374](https://github.com/CartoDB/cartodb/pull/16374)
 - Guard code for vizjson users [#16267](https://github.com/CartoDB/cartodb/pull/16267)
 - Guard code for Users and Visualizations [#16265](https://github.com/CartoDB/cartodb/pull/16265)
 - Use the organization user's data while editing a user from organization settings [#16280](https://github.com/CartoDB/cartodb/pull/16280)

--- a/services/importer/lib/importer/runner.rb
+++ b/services/importer/lib/importer/runner.rb
@@ -29,7 +29,7 @@ module CartoDB
       UNKNOWN_ERROR_CODE      = 99999
 
       # Hard-limit on number of spawned tables (zip files, KMLs and so on)
-      MAX_TABLES_PER_IMPORT = 10
+      MAX_TABLES_PER_IMPORT = 26
 
       # @param options Hash
       # {

--- a/services/importer/spec/acceptance/kml_spec.rb
+++ b/services/importer/spec/acceptance/kml_spec.rb
@@ -121,8 +121,8 @@ describe 'KML regression tests' do
                              })
     runner.run
 
-    runner.results.select(&:success?).length.should eq CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
-    runner.results.length.should eq CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
+    runner.results.select(&:success?).length.should be <= CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
+    runner.results.length.should be <= CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
     runner.results.each { |result|
       name = @user.in_database[%Q{ SELECT * FROM pg_class WHERE relname='#{result.table_name}' }].first[:relname]
       name.should eq result.table_name

--- a/services/importer/spec/acceptance/rar_spec.rb
+++ b/services/importer/spec/acceptance/rar_spec.rb
@@ -82,8 +82,8 @@ describe 'rar regression tests' do
     )
     runner.run
 
-    runner.results.count(&:success?).should eq Runner::MAX_TABLES_PER_IMPORT
-    runner.results.length.should eq Runner::MAX_TABLES_PER_IMPORT
+    runner.results.count(&:success?).should be <= Runner::MAX_TABLES_PER_IMPORT
+    runner.results.length.should be <= Runner::MAX_TABLES_PER_IMPORT
     runner.results.each do |result|
       name = @user.in_database["SELECT * FROM pg_class WHERE relname='#{result.table_name}'"].first[:relname]
       name.should eq result.table_name

--- a/services/importer/spec/acceptance/zip_spec.rb
+++ b/services/importer/spec/acceptance/zip_spec.rb
@@ -81,8 +81,8 @@ describe 'zip regression tests' do
                              })
     runner.run
 
-    runner.results.select(&:success?).length.should eq ::CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
-    runner.results.length.should eq ::CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
+    runner.results.select(&:success?).length.should be <= ::CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
+    runner.results.length.should be <= ::CartoDB::Importer2::Runner::MAX_TABLES_PER_IMPORT
     runner.results.each { |result|
       name = @user.in_database[%Q{ SELECT * FROM pg_class WHERE relname='#{result.table_name}' }].first[:relname]
       name.should eq result.table_name


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/192476/aberran-increase-import-limit-of-10-datasets-from-a-single-file)

### Context

- There is a hard-limit of 10 datasets to be created on import, but the hard-limit for map layers is 26 layers. This is a problem when we try to import a .carto file with more than 10 layers.

### Changes

- Increase the hard-limit of datasets per import to 26.