### PR TITLE
[sc189965] Invalidate sessions on 'session_salt' issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Development
 - Add new DO Catalog route for internal usage [#16342](https://github.com/CartoDB/cartodb/pull/16342)
 - Improve info for :update_user command  [#16363](https://github.com/CartoDB/cartodb/pull/16363)
 - Disable email validation in DO Premium Subscriptions [#16309](https://github.com/CartoDB/cartodb/pull/16309)
+- Invalidate sessions on 'session_salt' issue [#16376](https://github.com/CartoDB/cartodb/pull/16376)
 - Hide sharing tab from viewer in on-premises [#16299](https://github.com/CartoDB/cartodb/pull/16299)
 - Remove all references to Spatial Data Catalog and Kepler GL maps in on-premises [#16293](https://github.com/CartoDB/cartodb/pull/16293)
 - Increase hard-limit of MAX_TABLES_PER_IMPORT [#16374](https://github.com/CartoDB/cartodb/pull/16374)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,6 +81,7 @@ class ApplicationController < ActionController::Base
     @current_viewer
   rescue Carto::ExpiredSessionError => e
     request.reset_session
+    current_user.try(:invalidate_all_sessions!)
     not_authorized(e)
   end
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -31,7 +31,7 @@
 
                 <% if @organization.nil? || @organization.auth_username_password_enabled %>
                   <div class="Sessions-field">
-                    <%= text_field_tag :email, CartoDB.extract_subdomain(request), :title => "Email or username", placeholder: "email or username", class: "CDB-Size-medium #{@organization.present? ? 'Sessions-input' : 'Sessions-navy-input'} topBorderRadius", autofocus: true %>
+                    <%= text_field_tag :email, (CartoDB.extract_subdomain(request) if @organization.blank?), :title => "Email or username", placeholder: "email or username", class: "CDB-Size-medium #{@organization.present? ? 'Sessions-input' : 'Sessions-navy-input'} topBorderRadius", autofocus: true %>
 
                     <% if @login_error %>
                       <div class="Sessions-fieldError js-Sessions-fieldError" data-content="<%= @login_error %>">!</div>


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/189965/alessandro238988-session-salt-issue)

### Context

- If `session_salt` value is not in sync with Central (whatever the reason), an exception is raised and the user is redirected. The idea would be then to force the `session_salt` update to fix the issue.

### Changes

- Invalidate all sessions on `session_salt` error.