### PR TITLE
[sc79798] Fix form to search dataset when generating a new API key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@ Development
 - Fix verification process for active users [#16337](https://github.com/CartoDB/cartodb/pull/16337)
 - Avoid updating analysis nodes more than once when moving layers in Builder [#16279](https://github.com/CartoDB/cartodb/pull/16279)
 - Fix subscription/sample filter for datasets [#16254](https://github.com/CartoDB/cartodb/pull/16254)
+- Fix form to search dataset when generating a new API key [#16378](https://github.com/CartoDB/cartodb/pull/16378)
 - Use fully qualified table name while creating a new map from a shared dataset [#16241](https://github.com/CartoDB/cartodb/pull/16241)
 - Render tileset viewer features in front of basemap [#16333](https://github.com/CartoDB/cartodb/pull/16333)
 - Rake task to migrate legacy synchronizations [#16353](https://github.com/CartoDB/cartodb/pull/16353)

--- a/lib/assets/javascripts/dashboard/components/table-grants/table-grants-view.js
+++ b/lib/assets/javascripts/dashboard/components/table-grants/table-grants-view.js
@@ -121,5 +121,5 @@ module.exports = CoreView.extend({
 
   _onSearchChanged: _.debounce(function (event) {
     this._userTablesModel.setQuery(event.target.value);
-  }, 500, this)
+  }, 500)
 });

--- a/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
+++ b/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
@@ -208,11 +208,6 @@ describe('dashboard/components/table-grants/table-grants-view', function () {
   describe('._onSearchChanged', function () {
     beforeEach(function () {
       view = createViewFn();
-      jasmine.clock().install();
-    });
-
-    afterEach(function() {
-      jasmine.clock().uninstall();
     });
 
     it('should call userTablesModel.setQuery', function () {
@@ -225,9 +220,10 @@ describe('dashboard/components/table-grants/table-grants-view', function () {
       };
 
       view._onSearchChanged(event);
-      jasmine.clock().tick(600);
 
-      expect(userTablesModel.setQuery).toHaveBeenCalledWith(event.target.value);
+      setTimeout(function() {
+        expect(userTablesModel.setQuery).toHaveBeenCalledWith(event.target.value);
+      }, 600);
     });
   });
 });

--- a/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
+++ b/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
@@ -208,6 +208,11 @@ describe('dashboard/components/table-grants/table-grants-view', function () {
   describe('._onSearchChanged', function () {
     beforeEach(function () {
       view = createViewFn();
+      jasmine.clock().install();
+    });
+
+    afterEach(function() {
+      jasmine.clock().uninstall();
     });
 
     it('should call userTablesModel.setQuery', function () {
@@ -220,6 +225,7 @@ describe('dashboard/components/table-grants/table-grants-view', function () {
       };
 
       view._onSearchChanged(event);
+      jasmine.clock().tick(600);
 
       expect(userTablesModel.setQuery).toHaveBeenCalledWith(event.target.value);
     });

--- a/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
+++ b/lib/assets/test/spec/dashboard/components/table-grants-view.spec.js
@@ -221,7 +221,7 @@ describe('dashboard/components/table-grants/table-grants-view', function () {
 
       view._onSearchChanged(event);
 
-      setTimeout(function() {
+      setTimeout(function () {
         expect(userTablesModel.setQuery).toHaveBeenCalledWith(event.target.value);
       }, 600);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.278",
+  "version": "1.0.0-assets.279",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.278",
+  "version": "1.0.0-assets.279",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/79798/westermann-gruppe-search-dataset-when-generating-api-key)

### Changes

- Removing the third parameter from `debounce` call, since we want the original behavior, not the [immediate one](https://underscorejs.org/#debounce).