### PR TITLE
Fixing rubocop integration

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,10 +11,11 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.5
+      - run: 'gem install activesupport -v 6.1.4.4'
       - name: Rubocop linter
         uses: reviewdog/action-rubocop@v1
         with:
-          rubocop_version: 1.12.1
+          rubocop_version: 1.23.0
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: error

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.5.7
       - run: 'gem install activesupport -v 6.1.4.4'
       - name: Rubocop linter
         uses: reviewdog/action-rubocop@v1

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5.7
+          ruby-version: 2.5.8
       - run: 'gem install activesupport -v 6.1.4.4'
       - name: Rubocop linter
         uses: reviewdog/action-rubocop@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
   - "vendor/**/*"
   - "db/schema.rb"

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Development
 * Setting to enable/disable random username generation on SAML authentication process [16372](https://github.com/CartoDB/cartodb/pull/16372)
 
 ### Bug fixes / enhancements
+- Fix rubocop integration [#16382](https://github.com/CartoDB/cartodb/pull/16382)
 - Add marginTop to Page when notification is displayed [#16355](https://github.com/CartoDB/cartodb/pull/16355)
 - Add "element" param to DO-Catalog entry function [#16343](https://github.com/CartoDB/cartodb/pull/16343)
 - Add new DO Catalog route for internal usage [#16342](https://github.com/CartoDB/cartodb/pull/16342)

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -5,30 +5,18 @@ include CartoDB::Importer2
 
 module FileUtils
   class Entry_
+
     def copy_file(dest)
-      Open3.capture2('cp', path(), dest)
+      Open3.capture2('cp', path, dest)
     end
+
   end
 end
 
 describe Unp do
   describe '#run' do
     it 'extracts the contents of the file' do
-      # zipfile   = file_factory
-
-      dir = '/var/tmp/bogus'
-      filename = 'bogus.zip'
-      zipfile = "#{dir}/#{filename}"
-
-      FileUtils.rm(zipfile) if File.exists?(zipfile)
-      FileUtils.rm_r(dir)   if File.exists?(dir)
-      FileUtils.mkdir_p(dir)
-  
-      new_dir = File.expand_path("../fixtures/#{filename}", File.dirname(__FILE__))
-
-
-      FileUtils.cp(new_dir, zipfile)
-
+      zipfile   = file_factory
       unp       = Unp.new
 
       unp.run(zipfile)

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -5,9 +5,11 @@ include CartoDB::Importer2
 
 module FileUtils
   class Entry_ # rubocop:disable ClassAndModuleCamelCase, DepartmentName
+
     def copy_file(dest)
       Open3.capture2('cp', path, dest)
     end
+
   end
 end
 
@@ -225,7 +227,7 @@ describe Unp do
     end
 
     it 'raises if unp is not found' do
-      Open3.stubs('capture3').with('which unp').returns [0, 0, 1]
+      Open3.expects('capture3').with('which unp').returns [0, 0, 1]
       unp = Unp.new
 
       expect { unp.command_for('wadus') }.to raise_error InstallError

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -217,7 +217,8 @@ describe Unp do
     end
 
     it 'raises if unp is not found' do
-      Open3.expects('capture3').with('which unp').returns [0, 0, 1]
+      Open3.stub(:capture3).and_return([0, 0, 1])
+
       unp = Unp.new
 
       expect { unp.command_for('wadus') }.to raise_error InstallError

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -3,10 +3,32 @@ require_relative '../../lib/importer/unp'
 
 include CartoDB::Importer2
 
+module FileUtils
+  class Entry_
+    def copy_file(dest)
+      Open3.capture2('cp', path(), dest)
+    end
+  end
+end
+
 describe Unp do
   describe '#run' do
     it 'extracts the contents of the file' do
-      zipfile   = file_factory
+      # zipfile   = file_factory
+
+      dir = '/var/tmp/bogus'
+      filename = 'bogus.zip'
+      zipfile = "#{dir}/#{filename}"
+
+      FileUtils.rm(zipfile) if File.exists?(zipfile)
+      FileUtils.rm_r(dir)   if File.exists?(dir)
+      FileUtils.mkdir_p(dir)
+  
+      new_dir = File.expand_path("../fixtures/#{filename}", File.dirname(__FILE__))
+
+
+      FileUtils.cp(new_dir, zipfile)
+
       unp       = Unp.new
 
       unp.run(zipfile)
@@ -353,7 +375,8 @@ describe Unp do
     FileUtils.rm_r(dir)   if File.exists?(dir)
     FileUtils.mkdir_p(dir)
 
-    FileUtils.cp(File.join(File.dirname(__FILE__), "../fixtures/#{filename}"), zipfile)
+    new_dir = File.expand_path("../fixtures/#{filename}", File.dirname(__FILE__))
+    FileUtils.cp(new_dir, zipfile)
 
     zipfile
   end

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -5,11 +5,9 @@ include CartoDB::Importer2
 
 module FileUtils
   class Entry_ # rubocop:disable ClassAndModuleCamelCase, DepartmentName
-
     def copy_file(dest)
       Open3.capture2('cp', path, dest)
     end
-
   end
 end
 
@@ -227,8 +225,7 @@ describe Unp do
     end
 
     it 'raises if unp is not found' do
-      Open3.stub(:capture3).and_return([0, 0, 1])
-
+      Open3.stubs('capture3').with('which unp').returns [0, 0, 1]
       unp = Unp.new
 
       expect { unp.command_for('wadus') }.to raise_error InstallError

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/importer/unp'
 include CartoDB::Importer2
 
 module FileUtils
-  class Entry_
+  class Entry_ # rubocop:disable ClassAndModuleCamelCase
 
     def copy_file(dest)
       Open3.capture2('cp', path, dest)

--- a/services/importer/spec/unit/unp_spec.rb
+++ b/services/importer/spec/unit/unp_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/importer/unp'
 include CartoDB::Importer2
 
 module FileUtils
-  class Entry_ # rubocop:disable ClassAndModuleCamelCase
+  class Entry_ # rubocop:disable ClassAndModuleCamelCase, DepartmentName
 
     def copy_file(dest)
       Open3.capture2('cp', path, dest)


### PR DESCRIPTION
## Description

https://github.com/CartoDB/cartodb-central/pull/3171
https://app.shortcut.com/cartoteam/story/199091/rubocop-github-action-is-broken-in-cartodb


Rubocop integration was broken since long time ago, although it was reporting **success** as the return code. A few days ago, it 
started to report an **error return code** and that's when @moicalcob reported that it was broken.

We've updated `rubocop` to the latest version and point to **ruby 2.5** in the `.rubocop.yml` config file. Additionally, we had to pin the `activesupport` gem version to `6.1.4.4` to make it work.