### PR TITLE
Do not use git:// protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "lib/assets/javascripts/cdb"]
 	path = lib/assets/javascripts/cdb
-        url = git://github.com/CartoDB/carto.js.git
+        url = https://github.com/CartoDB/carto.js.git
 [submodule "app/assets/stylesheets/old_common"]
 	path = app/assets/stylesheets/old_common
-	url = git://github.com/CartoDB/cartodb.css.git
+	url = https://github.com/CartoDB/cartodb.css.git
 [submodule "lib/sql"]
 	path = lib/sql
-	url = git://github.com/CartoDB/cartodb-postgresql.git
+	url = https://github.com/CartoDB/cartodb-postgresql.git
 [submodule "private"]
 	path = private
 	url = git@github.com:CartoDB/cartodb-private.git

--- a/doc/manual/source/install.rst
+++ b/doc/manual/source/install.rst
@@ -202,7 +202,7 @@ SQL API
 
   .. code-block:: bash
 
-    git clone git://github.com/CartoDB/CartoDB-SQL-API.git
+    git clone https://github.com/CartoDB/CartoDB-SQL-API.git
     cd CartoDB-SQL-API
 
 * Install npm dependencies
@@ -232,7 +232,7 @@ MAPS API
 
   .. code-block:: bash
 
-    git clone git://github.com/CartoDB/Windshaft-cartodb.git
+    git clone https://github.com/CartoDB/Windshaft-cartodb.git
     cd Windshaft-cartodb
 
 * Install yarn dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,7 +2674,7 @@
         "d3-time-format": "2.1.0",
         "jquery": "2.1.4",
         "mustache": "1.1.0",
-        "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+        "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
         "postcss": "5.0.19",
         "promise-polyfill": "^6.1.0",
         "torque.js": "github:CartoDB/torque#master",
@@ -2697,8 +2697,8 @@
           "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "perfect-scrollbar": {
-          "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-          "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+          "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+          "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
         },
         "torque.js": {
           "version": "github:CartoDB/torque#11b73bbc9a55b7c67c1ab72759a58eb417b88555",
@@ -6363,8 +6363,8 @@
           }
         },
         "perfect-scrollbar": {
-          "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-          "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+          "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+          "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
         },
         "torque.js": {
           "version": "github:CartoDB/torque#11b73bbc9a55b7c67c1ab72759a58eb417b88555",
@@ -22838,7 +22838,7 @@
         "d3-time-format": "2.1.0",
         "jquery": "2.1.4",
         "mustache": "1.1.0",
-        "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+        "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
         "postcss": "5.0.19",
         "promise-polyfill": "^6.1.0",
         "torque.js": "github:CartoDB/torque#master",
@@ -30239,8 +30239,8 @@
       "dev": true
     },
     "perfect-scrollbar": {
-      "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-      "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+      "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+      "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CartoDB/cartodb.git"
+    "url": "https://github.com/CartoDB/cartodb.git"
   },
   "author": {
     "name": "CARTO",
@@ -65,7 +65,7 @@
     "moment": "2.18.1",
     "moment-timezone": "^0.5.13",
     "node-polyglot": "1.0.0",
-    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+    "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",
     "postcss-scss": "0.4.0",
     "postcss-strip-inline-comments": "0.1.5",


### PR DESCRIPTION
According to recent GitHub [changes](https://github.blog/2021-09-01-improving-git-protocol-security-github/), `git://` protocol is treated as insecure and must not be used anymore. This PR replaces `git://` usages with `https://` ones wherever possible.