### PR TITLE
Allow importing private datasets with exhausted public datasets quota

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ Development
 - Fix search in _Filter by Column Value_ analysis [#16310](https://github.com/CartoDB/cartodb/pull/16310)
 - Use Google Maps provider if the base layer is Google [#16314](https://github.com/CartoDB/cartodb/pull/16314)
 - Allow importing datasets with exhausted map quota [#16320](https://github.com/CartoDB/cartodb/pull/16320)
+- Allow importing private datasets with exhausted public datasets quota [#16389](https://github.com/CartoDB/cartodb/pull/16389)
 - Fix empty ArcGIS imports [#16322](https://github.com/CartoDB/cartodb/pull/16322)
 - Fix data overwrite when a user is promoted to admin [#16351](https://github.com/CartoDB/cartodb/pull/16351)
 - Update analysis schema when a user is promoted to organization owner [#16358](https://github.com/CartoDB/cartodb/pull/16358)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -74,8 +74,10 @@ module CartoDB
           v.type == Carto::Visualization::TYPE_CANONICAL && v.privacy != Carto::Visualization::PRIVACY_PRIVATE
         end
         quota_checker = CartoDB::QuotaChecker.new(data_import.user)
+        if public_datasets.count == 0 then
+          return
+        end
         return unless quota_checker.will_be_over_public_dataset_quota?(public_datasets.count)
-
         log('Results would set dataset overquota')
         raise CartoDB::Importer2::PublicDatasetQuotaExceededError.new
       end

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -73,10 +73,7 @@ module CartoDB
         public_datasets = visualizations.select do |v|
           v.type == Carto::Visualization::TYPE_CANONICAL && v.privacy != Carto::Visualization::PRIVACY_PRIVATE
         end
-        if public_datasets.count == 0 then
-          return
-        end
-
+        return if public_datasets.zero?
         quota_checker = CartoDB::QuotaChecker.new(data_import.user)
         return unless quota_checker.will_be_over_public_dataset_quota?(public_datasets.count)
 

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -73,7 +73,7 @@ module CartoDB
         public_datasets = visualizations.select do |v|
           v.type == Carto::Visualization::TYPE_CANONICAL && v.privacy != Carto::Visualization::PRIVACY_PRIVATE
         end
-        return if public_datasets.zero?
+        return if public_datasets.count.zero?
 
         quota_checker = CartoDB::QuotaChecker.new(data_import.user)
         return unless quota_checker.will_be_over_public_dataset_quota?(public_datasets.count)

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -73,11 +73,13 @@ module CartoDB
         public_datasets = visualizations.select do |v|
           v.type == Carto::Visualization::TYPE_CANONICAL && v.privacy != Carto::Visualization::PRIVACY_PRIVATE
         end
-        quota_checker = CartoDB::QuotaChecker.new(data_import.user)
         if public_datasets.count == 0 then
           return
         end
+
+        quota_checker = CartoDB::QuotaChecker.new(data_import.user)
         return unless quota_checker.will_be_over_public_dataset_quota?(public_datasets.count)
+
         log('Results would set dataset overquota')
         raise CartoDB::Importer2::PublicDatasetQuotaExceededError.new
       end

--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -74,6 +74,7 @@ module CartoDB
           v.type == Carto::Visualization::TYPE_CANONICAL && v.privacy != Carto::Visualization::PRIVACY_PRIVATE
         end
         return if public_datasets.zero?
+
         quota_checker = CartoDB::QuotaChecker.new(data_import.user)
         return unless quota_checker.will_be_over_public_dataset_quota?(public_datasets.count)
 

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -724,7 +724,7 @@ describe CartoDB::Connector::Importer do
         data_source: filepath,
         updated_at: Time.now.utc,
         append: false,
-        create_visualization: true
+        create_visualization: true,
         privacy: (::UserTable::PRIVACY_VALUES_TO_TEXTS.invert)['public']
       )
       @data_import.values[:data_source] = filepath

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -715,7 +715,7 @@ describe CartoDB::Connector::Importer do
       @user.save
     end
 
-    it 'fails to import a visualization export if public dataset quota is exceeded' do
+    it 'fails to import a public visualization export if public dataset quota is exceeded' do
       filepath = "#{Rails.root}/services/importer/spec/fixtures/public_visualization_export_with_csv_table.carto"
       @user.public_dataset_quota = 0
       @user.save
@@ -725,6 +725,7 @@ describe CartoDB::Connector::Importer do
         updated_at: Time.now.utc,
         append: false,
         create_visualization: true
+        privacy: (::UserTable::PRIVACY_VALUES_TO_TEXTS.invert)['public']
       )
       @data_import.values[:data_source] = filepath
 

--- a/spec/connectors/importer_spec.rb
+++ b/spec/connectors/importer_spec.rb
@@ -724,8 +724,7 @@ describe CartoDB::Connector::Importer do
         data_source: filepath,
         updated_at: Time.now.utc,
         append: false,
-        create_visualization: true,
-        privacy: (::UserTable::PRIVACY_VALUES_TO_TEXTS.invert)['public']
+        create_visualization: true
       )
       @data_import.values[:data_source] = filepath
 


### PR DESCRIPTION
### Resources

- [Shortcut](https://app.shortcut.com/cartoteam/story/206928/pg-admin-set-datasets-and-public-map-quota-to-0)

### Context

Whenever a new dataset is imported into CARTO, there is a check to ensure that the public dataset quota will not be exceeded. 

This check compares the user's public dataset quota with the number of current public datasets plus the number of public datasets to be imported.

### Changes

With this small PR we aim to avoid performing this check when the dataset to be imported is not public, so we open the use case in which the user is restricted not to share datasets anymore without affecting its existent datasets nor their current import processes. 

- `app/connectors/importer.rb` Modify the `check_dataset_quotas` function to avoid performing the `will_be_over_public_dataset_quota?` check if the `public_datasets.count` is zero. 

