### PR TITLE
[sc207379] Update analysis schemas after giving required permissions on user promotion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ Development
 - Disable email validation in DO Premium Subscriptions [#16309](https://github.com/CartoDB/cartodb/pull/16309)
 - Invalidate sessions on 'session_salt' issue [#16376](https://github.com/CartoDB/cartodb/pull/16376)
 - Hide sharing tab from viewer in on-premises [#16299](https://github.com/CartoDB/cartodb/pull/16299)
+- Update analysis schemas after giving required permissions on user promotion [#16390](https://github.com/CartoDB/cartodb/pull/16390)
 - Add timeout for SQL API exports [#16377](https://github.com/CartoDB/cartodb/pull/16377)
 - Remove all references to Spatial Data Catalog and Kepler GL maps in on-premises [#16293](https://github.com/CartoDB/cartodb/pull/16293)
 - Increase hard-limit of MAX_TABLES_PER_IMPORT [#16374](https://github.com/CartoDB/cartodb/pull/16374)

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -1212,7 +1212,6 @@ module CartoDB
 
           create_public_db_user
           set_database_search_path
-          update_analyses_schema
         end
       rescue StandardError => e
         # Undo metadata changes if process fails

--- a/app/models/user/user_organization.rb
+++ b/app/models/user/user_organization.rb
@@ -32,6 +32,7 @@ module CartoDB
       @owner.db_service.reset_user_schema_permissions
 
       @owner.db_service.setup_organization_user_schema
+      @owner.db_service.update_analyses_schema
       @owner.update organization_id: @organization.id
       @owner.db_service.monitor_user_notification
       @active = true


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/207379/sounddiplomacy-account-upgrade-made-no-maps-render-for-account)

### Context

- The process to update analysis schema when a user is promoted to organization owner was failing because the user didn't have the required permissions on the new schema. The permissions are required because before changing the query, it is tested with `EXPLAIN` [here](https://github.com/CartoDB/cartodb/blob/master/lib/carto/query_rewriter.rb#L18).

### Changes

- Update analyses schema after giving required permissions to the user.