### PR TITLE
[sc206349] Propagate 'invitation_token' when there is an error signing-up with Google

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@ Development
 - Add marginTop to Page when notification is displayed [#16355](https://github.com/CartoDB/cartodb/pull/16355)
 - Add "element" param to DO-Catalog entry function [#16343](https://github.com/CartoDB/cartodb/pull/16343)
 - Add new DO Catalog route for internal usage [#16342](https://github.com/CartoDB/cartodb/pull/16342)
+- Propagate 'invitation_token' when there is an error signing-up with Google [#16391](https://github.com/CartoDB/cartodb/pull/16391)
 - Improve info for :update_user command  [#16363](https://github.com/CartoDB/cartodb/pull/16363)
 - Disable email validation in DO Premium Subscriptions [#16309](https://github.com/CartoDB/cartodb/pull/16309)
 - Invalidate sessions on 'session_salt' issue [#16376](https://github.com/CartoDB/cartodb/pull/16376)

--- a/app/views/signup/signup.html.erb
+++ b/app/views/signup/signup.html.erb
@@ -33,7 +33,7 @@
 
             <%= form_for @user, url: CartoDB.url(self, 'signup_organization_user'),  html: { class: "js-Loading-form" } do |f| %>
 
-              <input type="hidden" value="<%= params[:invitation_token] %>" id="invitation_token" name="invitation_token" />
+              <input type="hidden" value="<%= params[:invitation_token] || @invitation_token %>" id="invitation_token" name="invitation_token" />
 
               <div class="Sessions-fieldsGroup">
                 <% if @organization.auth_username_password_enabled || duplicated_username_prompt? %>


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/206349/instacart-admin-error-fake-token-sent-for-email-on-log-in)

### Context

- The `invitation_token` is not being properly propagated if we are signing up using an invitation + Google Oauth + there is an error (for example, the username has invalid characters).

### Changes

- Get `invitation_token` from instance variable to make the form support Google sign-up.