### PR TITLE
Updating fastly urls for static content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.282",
+  "version": "1.0.0-assets.283",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.283",
+  "version": "1.0.0-assets.284",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.280",
+  "version": "1.0.0-assets.281",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.281",
+  "version": "1.0.0-assets.282",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.284",
+  "version": "1.0.0-assets.285",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Updating fastly urls for static content

- For legacy reasons we are using `*.global.fastly.ssl.net` URLs, because they give you SSL for free without the need of purchasing a certificate.
- Now it's time to go for custom `*.cartocdn.com` URLs, to avoid issues in some clients where CARTO is not working, because `global.fastly.ssl.net` domain is blocked: https://app.shortcut.com/cartoteam/story/207532/change-the-domain-in-fastly-to-unblock-carto2-in-china
- Replace `carto-stag-{s}.global.ssl.fastly.net` with `https://{s}.staging.cartocdn.com"`

## Related PRs
- Staging: https://github.com/CartoDB/cartodb-platform/pull/7230/files
- Production: WIP