### PR TITLE
Bump assets version from v280 to v286

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,6 +88,7 @@ Development
 - Add a new rake to update a user username [#16370](https://github.com/CartoDB/cartodb/pull/16370)
 - Add a check before destroying user tables in order to avoid deleting dependent maps [#16381](https://github.com/CartoDB/cartodb/pull/16381)
 - Fix duplicated attributions in datasets [#16384](https://github.com/CartoDB/cartodb/pull/16384)
+- Moving assets cdn domain from global.ssl.fastly.net to libs.cartocdn.com [#16399](https://github.com/CartoDB/cartodb/pull/16399)
 
 4.45.0 (2021-04-14)
 -------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.280",
+  "version": "1.0.0-assets.286",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9857,9 +9857,9 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader@16.5.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
-          "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
+          "version": "npm:vue-loader@16.8.3",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -9917,9 +9917,9 @@
               }
             },
             "loader-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+              "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
               "dev": true,
               "optional": true,
               "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.280",
+  "version": "1.0.0-assets.286",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Ticket
https://app.shortcut.com/cartoteam/story/207532/change-the-domain-in-fastly-to-unblock-carto2-in-china
## Description
Due to China's Firewall we need to change the domains where the assets are served to libs.cartocdn.com (production) and libs-staging.cartocdn.com (staging), so we need to regenerate the assets. 

Related Cartodb-platfom PR : https://github.com/CartoDB/cartodb-platform/pull/7234

The gap between versions is to align Staging and Prod