### PR TITLE
[sc220191] Notification about data migrations to CARTO 3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/CartoDB/cartodb-postgresql.git
 [submodule "private"]
 	path = private
-	url = https@github.com:CartoDB/cartodb-private.git
+	url = git@github.com:CartoDB/cartodb-private.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "lib/assets/javascripts/cdb"]
 	path = lib/assets/javascripts/cdb
-        url = git://github.com/CartoDB/carto.js.git
+        url = https://github.com/CartoDB/carto.js.git
 [submodule "app/assets/stylesheets/old_common"]
 	path = app/assets/stylesheets/old_common
-	url = git://github.com/CartoDB/cartodb.css.git
+	url = https://github.com/CartoDB/cartodb.css.git
 [submodule "lib/sql"]
 	path = lib/sql
-	url = git://github.com/CartoDB/cartodb-postgresql.git
+	url = https://github.com/CartoDB/cartodb-postgresql.git
 [submodule "private"]
 	path = private
-	url = git@github.com:CartoDB/cartodb-private.git
+	url = https@github.com:CartoDB/cartodb-private.git

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ Development
 * Setting to enable/disable import notifications [16354](https://github.com/CartoDB/cartodb/pull/16354)
 * Setting to enable/disable random username generation on SAML authentication process [16372](https://github.com/CartoDB/cartodb/pull/16372)
 * Add type guessing capabilities to the ArcGIS connector [#16385](https://github.com/CartoDB/cartodb/pull/16385)
+* Add notification about data migrations to CARTO 3 [#16405](https://github.com/CartoDB/cartodb/pull/16405)
 
 ### Bug fixes / enhancements
 - Fix rubocop integration [#16382](https://github.com/CartoDB/cartodb/pull/16382)

--- a/lib/assets/javascripts/new-dashboard/App.vue
+++ b/lib/assets/javascripts/new-dashboard/App.vue
@@ -74,7 +74,9 @@ export default {
       return !!this.$store.getters['user/isNotificationVisible'];
     },
     isCarto3ReleaseNotificationVisible () {
-      return this.isEnterprise && this.displayCarto3ReleaseNotification;
+      // HACK: Disabling notification
+      return false;
+      //return this.isEnterprise && this.displayCarto3ReleaseNotification;
     },
     baseUrl () {
       return this.$store.state.user.base_url;

--- a/lib/assets/javascripts/new-dashboard/App.vue
+++ b/lib/assets/javascripts/new-dashboard/App.vue
@@ -76,7 +76,7 @@ export default {
     isCarto3ReleaseNotificationVisible () {
       // HACK: Disabling notification
       return false;
-      //return this.isEnterprise && this.displayCarto3ReleaseNotification;
+      // return this.isEnterprise && this.displayCarto3ReleaseNotification;
     },
     baseUrl () {
       return this.$store.state.user.base_url;

--- a/lib/assets/javascripts/new-dashboard/components/NavigationBar/NavigationBar.vue
+++ b/lib/assets/javascripts/new-dashboard/components/NavigationBar/NavigationBar.vue
@@ -120,8 +120,8 @@ export default {
   },
   mounted () {
     this.markPopupAsRead('popups.newPlatform');
-    //this.markPopupAsRead('feedback.popupWasShown');
-    //this.markPopupAsRead('popups.directDBConnection');
+    // this.markPopupAsRead('feedback.popupWasShown');
+    // this.markPopupAsRead('popups.directDBConnection');
   },
   computed: {
     hasDBFFActive () {

--- a/lib/assets/javascripts/new-dashboard/components/NavigationBar/NavigationBar.vue
+++ b/lib/assets/javascripts/new-dashboard/components/NavigationBar/NavigationBar.vue
@@ -39,11 +39,19 @@
         <UserDropdown :userModel="user" :notificationsCount="notificationsCount" :open="isDropdownOpen" :baseUrl="baseUrl" v-click-outside="closeDropdown" @linkClick="closeDropdown" />
 
         <NotificationPopup
+          v-if="!popupWasShown('popups.newPlatform') && isEnterprise"
+          class="notification-popup"
+          :title="$t('NewPlatformMessage.title')"
+          :message="$t('NewPlatformMessage.message')"
+          :messageHasHTML="true"
+          @click.native.stop.prevent="toggleDropdown"/>
+
+        <!-- <NotificationPopup
           v-if="!popupWasShown('feedback.popupWasShown')"
           class="notification-popup"
           :title="$t('FeedbackMessage.title')"
           :message="$t('FeedbackMessage.message')"
-          @click.native.stop.prevent="toggleDropdown"/>
+          @click.native.stop.prevent="toggleDropdown"/> -->
 
         <!-- <NotificationPopup
           v-if="!popupWasShown('popups.DataObservatorySamples') && !isOnPremise"
@@ -111,8 +119,9 @@ export default {
     };
   },
   mounted () {
-    this.markPopupAsRead('feedback.popupWasShown');
-    this.markPopupAsRead('popups.directDBConnection');
+    this.markPopupAsRead('popups.newPlatform');
+    //this.markPopupAsRead('feedback.popupWasShown');
+    //this.markPopupAsRead('popups.directDBConnection');
   },
   computed: {
     hasDBFFActive () {
@@ -132,6 +141,9 @@ export default {
         !this.isFirstTimeInDashboard &&
         !this.hasDropdownOpenedForFirstTime &&
         !this.popupWasShown;
+    },
+    isEnterprise () {
+      return this.$props.user && this.$props.user.is_enterprise;
     }
   },
   methods: {

--- a/lib/assets/javascripts/new-dashboard/components/Popups/NotificationPopup.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Popups/NotificationPopup.vue
@@ -7,9 +7,9 @@
         {{ title }}
       </p>
 
-      <template v-for="paragraph in message">
-        <p class="notification__paragraph text is-small" v-if="messageHasHTML" v-html="paragraph"></p>
-        <p class="notification__paragraph text is-small" v-else>{{ paragraph }}</p>
+      <template v-for="(paragraph, index) in message">
+        <p class="notification__paragraph text is-small" v-if="messageHasHTML" v-html="paragraph" :key="index"></p>
+        <p class="notification__paragraph text is-small" v-else :key="index">{{ paragraph }}</p>
       </template>
     </div>
   </a>

--- a/lib/assets/javascripts/new-dashboard/components/Popups/NotificationPopup.vue
+++ b/lib/assets/javascripts/new-dashboard/components/Popups/NotificationPopup.vue
@@ -7,11 +7,10 @@
         {{ title }}
       </p>
 
-      <p class="notification__paragraph text is-small" v-if="messageHasHTML" v-html="message"></p>
-
-      <p class="notification__paragraph text is-small" v-if="!messageHasHTML">
-        {{ message }}
-      </p>
+      <template v-for="paragraph in message">
+        <p class="notification__paragraph text is-small" v-if="messageHasHTML" v-html="paragraph"></p>
+        <p class="notification__paragraph text is-small" v-else>{{ paragraph }}</p>
+      </template>
     </div>
   </a>
 </template>
@@ -21,7 +20,7 @@ export default {
   name: 'NotificationPopup',
   props: {
     title: String,
-    message: String,
+    message: Array,
     messageHasHTML: {
       type: Boolean,
       default: false

--- a/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
+++ b/lib/assets/javascripts/new-dashboard/i18n/locales/en.json
@@ -557,6 +557,13 @@
     "maps": "0 maps | {maps} map | {maps} maps",
     "datasets": "0 datasets | {datasets} dataset | {datasets} datasets"
   },
+  "NewPlatformMessage": {
+    "title": "New version of the CARTO Platform",
+    "message": [
+      "To start using the latest version of our platform, please create your account <a href='https://carto.com/signup' target='_blank'>here</a>. We will then align it to your current subscription plan.",
+      "If you need help migrating your data to the new version of CARTO, reach out to our <a href='mailto:enterprise-support@carto.com'>Support team</a>."
+    ]
+  },
   "FeedbackMessage": {
     "title": "Let us know what you think.",
     "message": "Missing something? Should we be doing something differently?"

--- a/lib/assets/test/spec/new-dashboard/unit/specs/components/__snapshots__/NavigationBar.spec.js.snap
+++ b/lib/assets/test/spec/new-dashboard/unit/specs/components/__snapshots__/NavigationBar.spec.js.snap
@@ -70,7 +70,7 @@ exports[`NavigationBar.vue should render regular navbar with user dropdown close
     <div class="navbar-user">
       <div class="navbar-avatar" style="background-image: url(//cartodb-libs.global.ssl.fastly.net/cartodbui/assets/unversioned/images/avatars/avatar_ghost_yellow.png);"></div>
       <userdropdown-stub baseurl="" usermodel="[object Object]"></userdropdown-stub>
-      <notificationpopup-stub title="FeedbackMessage.title" message="FeedbackMessage.message" class="notification-popup"></notificationpopup-stub>
+      <!---->
     </div> <span class="navbar-searchClose"><img svg-inline="" src="../../assets/icons/navbar/close.svg"></span>
   </div>
 </nav>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,7 +2674,7 @@
         "d3-time-format": "2.1.0",
         "jquery": "2.1.4",
         "mustache": "1.1.0",
-        "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+        "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
         "postcss": "5.0.19",
         "promise-polyfill": "^6.1.0",
         "torque.js": "github:CartoDB/torque#master",
@@ -2697,8 +2697,8 @@
           "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "perfect-scrollbar": {
-          "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-          "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+          "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+          "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
         },
         "torque.js": {
           "version": "github:CartoDB/torque#11b73bbc9a55b7c67c1ab72759a58eb417b88555",
@@ -6363,8 +6363,8 @@
           }
         },
         "perfect-scrollbar": {
-          "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-          "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+          "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+          "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
         },
         "torque.js": {
           "version": "github:CartoDB/torque#11b73bbc9a55b7c67c1ab72759a58eb417b88555",
@@ -22838,7 +22838,7 @@
         "d3-time-format": "2.1.0",
         "jquery": "2.1.4",
         "mustache": "1.1.0",
-        "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+        "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
         "postcss": "5.0.19",
         "promise-polyfill": "^6.1.0",
         "torque.js": "github:CartoDB/torque#master",
@@ -30239,8 +30239,8 @@
       "dev": true
     },
     "perfect-scrollbar": {
-      "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-      "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+      "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+      "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.286",
+  "version": "1.0.0-assets.287",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "moment": "2.18.1",
     "moment-timezone": "^0.5.13",
     "node-polyglot": "1.0.0",
-    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+    "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",
     "postcss-scss": "0.4.0",
     "postcss-strip-inline-comments": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.286",
+  "version": "1.0.0-assets.287",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/220191/notification-about-data-migrations-to-carto3-in-carto2-dashboard)

### Changes

- Creating notification about data migrations (only for Enterprise users).
- Disable old banner about CARTO 3 release.