### PR TITLE
Updating github URLs to meet github security standards

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "lib/assets/javascripts/cdb"]
 	path = lib/assets/javascripts/cdb
-        url = git://github.com/CartoDB/carto.js.git
+        url = git@github.com:CartoDB/carto.js.git
 [submodule "app/assets/stylesheets/old_common"]
 	path = app/assets/stylesheets/old_common
-	url = git://github.com/CartoDB/cartodb.css.git
+	url = git@github.com:CartoDB/cartodb.css.git
 [submodule "lib/sql"]
 	path = lib/sql
-	url = git://github.com/CartoDB/cartodb-postgresql.git
+	url = git@github.com:CartoDB/cartodb-postgresql.git
 [submodule "private"]
 	path = private
 	url = git@github.com:CartoDB/cartodb-private.git

--- a/doc/manual/source/install.rst
+++ b/doc/manual/source/install.rst
@@ -202,7 +202,7 @@ SQL API
 
   .. code-block:: bash
 
-    git clone git://github.com/CartoDB/CartoDB-SQL-API.git
+    git clone git@github.com:CartoDB/CartoDB-SQL-API.git
     cd CartoDB-SQL-API
 
 * Install npm dependencies
@@ -232,7 +232,7 @@ MAPS API
 
   .. code-block:: bash
 
-    git clone git://github.com/CartoDB/Windshaft-cartodb.git
+    git clone git@github.com:CartoDB/Windshaft-cartodb.git
     cd Windshaft-cartodb
 
 * Install yarn dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -2674,7 +2674,7 @@
         "d3-time-format": "2.1.0",
         "jquery": "2.1.4",
         "mustache": "1.1.0",
-        "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+        "perfect-scrollbar": "github:CartoDB/perfect-scrollbar.git#master",
         "postcss": "5.0.19",
         "promise-polyfill": "^6.1.0",
         "torque.js": "github:CartoDB/torque#master",
@@ -2697,8 +2697,8 @@
           "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
         },
         "perfect-scrollbar": {
-          "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-          "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+          "version": "github:CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+          "from": "github:CartoDB/perfect-scrollbar.git#master"
         },
         "torque.js": {
           "version": "github:CartoDB/torque#11b73bbc9a55b7c67c1ab72759a58eb417b88555",
@@ -6363,8 +6363,8 @@
           }
         },
         "perfect-scrollbar": {
-          "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-          "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+          "version": "github:CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+          "from": "github:CartoDB/perfect-scrollbar.git#master"
         },
         "torque.js": {
           "version": "github:CartoDB/torque#11b73bbc9a55b7c67c1ab72759a58eb417b88555",
@@ -22838,7 +22838,7 @@
         "d3-time-format": "2.1.0",
         "jquery": "2.1.4",
         "mustache": "1.1.0",
-        "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+        "perfect-scrollbar": "github:CartoDB/perfect-scrollbar.git#master",
         "postcss": "5.0.19",
         "promise-polyfill": "^6.1.0",
         "torque.js": "github:CartoDB/torque#master",
@@ -30239,8 +30239,8 @@
       "dev": true
     },
     "perfect-scrollbar": {
-      "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-      "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+      "version": "github:CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+      "from": "github:CartoDB/perfect-scrollbar.git#master"
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CartoDB/cartodb.git"
+    "url": "github:CartoDB/cartodb.git"
   },
   "author": {
     "name": "CARTO",
@@ -65,7 +65,7 @@
     "moment": "2.18.1",
     "moment-timezone": "^0.5.13",
     "node-polyglot": "1.0.0",
-    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+    "perfect-scrollbar": "github:CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",
     "postcss-scss": "0.4.0",
     "postcss-strip-inline-comments": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",
-    "url": "github:CartoDB/cartodb.git"
+    "url": "https://github.com/CartoDB/cartodb.git"
   },
   "author": {
     "name": "CARTO",


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/221282/carto2-deploys-are-broken-due-to-git-protocol-security-enforment
Github security notice: https://github.blog/2021-09-01-improving-git-protocol-security-github/
cartodb-platform: https://github.com/CartoDB/cartodb-platform/pull/7245/files
Deploy to staging cloud: http://deploy.int.cartodb.net/job/Carto_deploy_to_staging_(carto.com)_stag/3019/console

## **Changes**:
- Update github URLs from `git://github.com/CartoDB` to `git@github.com:CartoDB`
- Update `package.json` git URLs from `git://github.com/CartoDB` to `github:CartoDB`

## **Pending**
- [X] Go through the **submodule repositories** and update `package.json` github URLs.
   - [X] `[submodule "app/assets/stylesheets/old_common"](git@github.com:CartoDB/cartodb.css.git)`: Not required
   - [X] `[submodule "lib/assets/javascripts/cdb"]: git@github.com:CartoDB/carto.js.git `: [PR](https://github.com/CartoDB/carto.js/pull/2269) updated to https://github.com/CartoDB/carto.js/tree/v3.15.17
   - [X] `[submodule "lib/sql"]`: `git@github.com:CartoDB/cartodb-postgresql.git`: Not required
   - [X] `[submodule "private"]`: `git@github.com:CartoDB/cartodb-private.git`: Not required

### Before fix

```
$ git submodule status
 2961482abdc48f4472f954ada6418f6e62220f04 app/assets/stylesheets/old_common (remotes/origin/develop)
 05916e8a628d7493ccf10cead69a7d85a589b00e lib/assets/javascripts/cdb (v3.15.16-45-g05916e8a6)
 667ec0e32c7af1edb1dac3249bf7e889ca2176ba lib/sql (0.37.1)
 c812acf0b36a3ee8880a379e60079deb87f8f9fa private (heads/master)
```


## **Fixing the issue**

```
$ cat .gitmodules
[submodule "lib/assets/javascripts/cdb"]
        path = lib/assets/javascripts/cdb
        url = git@github.com:CartoDB/carto.js.git
[submodule "app/assets/stylesheets/old_common"]
        path = app/assets/stylesheets/old_common
        url = git@github.com:CartoDB/cartodb.css.git
[submodule "lib/sql"]
        path = lib/sql
        url = git@github.com:CartoDB/cartodb-postgresql.git
[submodule "private"]
        path = private
        url = git@github.com:CartoDB/cartodb-private.git


$ git submodule sync
Synchronizing submodule url for 'app/assets/stylesheets/old_common'
Synchronizing submodule url for 'lib/assets/javascripts/cdb'
Synchronizing submodule url for 'lib/sql'
Synchronizing submodule url for 'private'

$ git submodule update --init --recursive
Cloning into '/home/pepito/CartoDB/GitHub/cartodb/app/assets/stylesheets/old_common'...
Cloning into '/home/pepito/CartoDB/GitHub/cartodb/lib/assets/javascripts/cdb'...
Cloning into '/home/pepito/CartoDB/GitHub/cartodb/lib/sql'...
Submodule path 'app/assets/stylesheets/old_common': checked out '2961482abdc48f4472f954ada6418f6e62220f04'
Submodule path 'lib/assets/javascripts/cdb': checked out '05916e8a628d7493ccf10cead69a7d85a589b00e'
Submodule path 'lib/sql': checked out '667ec0e32c7af1edb1dac3249bf7e889ca2176ba'

$ cat .git/config
[core]
        repositoryformatversion = 0
        filemode = true
        bare = false
        logallrefupdates = true
[remote "origin"]
        url = git@github.com:/CartoDB/cartodb.git
        fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
        remote = origin
        merge = refs/heads/master
[submodule "app/assets/stylesheets/old_common"]
        active = true
        url = git@github.com:CartoDB/cartodb.css.git
[submodule "lib/assets/javascripts/cdb"]
        active = true
        url = git@github.com:CartoDB/carto.js.git
[submodule "lib/sql"]
        active = true
        url = git@github.com:CartoDB/cartodb-postgresql.git
[submodule "private"]
        active = true
        url = git@github.com:CartoDB/cartodb-private.git
```
