### PR TITLE
[sc188915] Reverse analysis selection order on new widget form

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Development
 - Add "element" param to DO-Catalog entry function [#16343](https://github.com/CartoDB/cartodb/pull/16343)
 - Add new DO Catalog route for internal usage [#16342](https://github.com/CartoDB/cartodb/pull/16342)
 - Propagate 'invitation_token' when there is an error signing-up with Google [#16391](https://github.com/CartoDB/cartodb/pull/16391)
+- Reverse analysis selection order on new widget form [#16412](https://github.com/CartoDB/cartodb/pull/16412)
 - Improve info for :update_user command  [#16363](https://github.com/CartoDB/cartodb/pull/16363)
 - Disable email validation in DO Premium Subscriptions [#16309](https://github.com/CartoDB/cartodb/pull/16309)
 - Invalidate sessions on 'session_salt' issue [#16376](https://github.com/CartoDB/cartodb/pull/16376)

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/layer-selector-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/layer-selector-view.js
@@ -58,7 +58,7 @@ module.exports = CoreView.extend({
       mouseOutAction: this._onMouseOut.bind(this)
     });
 
-    this._selectView.setValue(this.model.get('layer_index') || 0);
+    this._selectView.setValue(this.model.get('layer_index') || (options[0] || {}).val || 0);
     this.$el.html(this._selectView.render().el);
   },
 

--- a/lib/assets/javascripts/builder/components/modals/add-widgets/layer-selector-view.js
+++ b/lib/assets/javascripts/builder/components/modals/add-widgets/layer-selector-view.js
@@ -92,7 +92,7 @@ module.exports = CoreView.extend({
         color: layerDefModel.getColor(),
         isSourceType: nodeDefModel.isSourceType()
       };
-    });
+    }).reverse();
   },
 
   _bindEvents: function () {

--- a/lib/assets/test/spec/builder/components/modals/add-widgets/layer-selector-view.spec.js
+++ b/lib/assets/test/spec/builder/components/modals/add-widgets/layer-selector-view.spec.js
@@ -66,8 +66,8 @@ describe('components/modals/add-widgets/layer-selector-view', function () {
 
   it('should render table name and node id in the selected item', function () {
     expect(this.view).toBeDefined();
-    expect(this.view.$el.html()).toContain('foo');
-    expect(this.view.$el.html()).toContain('a1');
+    expect(this.view.$el.html()).toContain('bar');
+    expect(this.view.$el.html()).toContain('a2');
   });
 
   it('should render table name and node id in the custom list items', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.287",
+  "version": "1.0.0-assets.288",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.287",
+  "version": "1.0.0-assets.288",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/188915/avoid-recreating-location-data-services-analysis-after-widget-filtering-actions)

### Context

- We want to improve the usability of the form to create widgets, by reversing the analysis order. In general, we want the widget to filter the analysis on top of a layer, so this way we also prevent analysis from being recalculated by default.

### Changes

- Reverse analysis selection order on new widget form. 