### PR TITLE
Update browser version checker to allow Firefox/100.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@ Development
 - Disable email validation in DO Premium Subscriptions [#16309](https://github.com/CartoDB/cartodb/pull/16309)
 - Invalidate sessions on 'session_salt' issue [#16376](https://github.com/CartoDB/cartodb/pull/16376)
 - Hide sharing tab from viewer in on-premises [#16299](https://github.com/CartoDB/cartodb/pull/16299)
+- Update browser version checker to allow Firefox/100.0 [#16415](https://github.com/CartoDB/cartodb/pull/16415)
 - Update analysis schemas after giving required permissions on user promotion [#16390](https://github.com/CartoDB/cartodb/pull/16390)
 - Add timeout for SQL API exports [#16377](https://github.com/CartoDB/cartodb/pull/16377)
 - Remove all references to Spatial Data Catalog and Kepler GL maps in on-premises [#16293](https://github.com/CartoDB/cartodb/pull/16293)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -416,7 +416,7 @@ class ApplicationController < ActionController::Base
     return true if user_agent.nil?
 
     banned_regex = [
-      /msie [0-9]\./, /safari\/[0-4][0-2][0-2]/, /opera\/[0-8].[0-7]/, /firefox\/[0-2].[0-5]/
+      /msie [0-9]\./, /safari\/[0-4][0-2][0-2]/, /opera\/[0-8].[0-7]/, /firefox\/[0-2]\.[0-5]/
     ]
 
     if banned_regex.map { |re| user_agent.match(re) }.compact.first


### PR DESCRIPTION
### Resources

- [Shortcut story](https://app.shortcut.com/cartoteam/story/228649/ecfiber-website-carto-2-browser-not-supported-error-with-mozzila-firefox-v100-0)

### Context

- The browser version checker is not allowing Firefox/100.0

### Changes

- Fix the regular expression to allow `Firefox/100.0`