### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
     branches-ignore:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   cartodb-news:
     runs-on: ubuntu-18.04

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,9 @@ name: Node.js Tests
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/orm-check.yml
+++ b/.github/workflows/orm-check.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches-ignore:
       - master
+permissions:
+  contents: read
+
 jobs:
   orm-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
