### PR TITLE
Removing the full path on the canonical tag...

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ Development
 * Update banner to notify about data migrations to CARTO 3 [#16420](https://github.com/CartoDB/cartodb/pull/16420)
 
 ### Bug fixes / enhancements
+- Removing the full path from urls with filter parameters in the Spatial Data Catalog [#16426](https://github.com/CartoDB/cartodb/pull/16426)
 - Fix rubocop integration [#16382](https://github.com/CartoDB/cartodb/pull/16382)
 - Add marginTop to Page when notification is displayed [#16355](https://github.com/CartoDB/cartodb/pull/16355)
 - Add "element" param to DO-Catalog entry function [#16343](https://github.com/CartoDB/cartodb/pull/16343)

--- a/lib/assets/javascripts/do-catalog/router.js
+++ b/lib/assets/javascripts/do-catalog/router.js
@@ -94,7 +94,7 @@ router.afterEach(to => {
     if (!to.meta.titleInComponent) {
       document.title = to.meta.title(to);
     }
-    addCanonical(`https://carto.com/spatial-data-catalog/browser${to.fullPath}`);
+    addCanonical(`https://carto.com/spatial-data-catalog/browser${to.path}`);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.289",
+  "version": "1.0.0-assets.290",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb-ui",
-  "version": "1.0.0-assets.289",
+  "version": "1.0.0-assets.290",
   "description": "CARTO UI frontend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
...for urls with filter parameters for SEO purposes, in /spatial-data-catalog/browser/

[Shortcut story](https://app.shortcut.com/cartoteam/story/240818/high-medium-priority-onsite-technical-seo-tasks)

[Audit document](https://docs.google.com/document/d/1dH_1hIPo7LHh7lFuPjZJ8Hp_tPmTDN7mulS-xNHufmE/edit#heading=h.5ms46mcyier9) with details.


