### PR TITLE
Handle timeout swapping tables during sync process

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,6 +95,7 @@ Development
 - Fix duplicated attributions in datasets [#16384](https://github.com/CartoDB/cartodb/pull/16384)
 - Moving assets cdn domain from global.ssl.fastly.net to libs.cartocdn.com [#16399](https://github.com/CartoDB/cartodb/pull/16399)
 - Fix error while rolling back a user migration from one cloud to another [#16421](https://github.com/CartoDB/cartodb/pull/16421)
+- Add retry if a timeout is thrown when swapping the tables related with a sync process [#16430](https://github.com/CartoDB/cartodb/pull/16430)
 
 4.45.0 (2021-04-14)
 -------------------


### PR DESCRIPTION
* If a timeout is thrown during the swapping process related with a sync table, we'll wait one minute and retry the swap