### PR TITLE
Add AUTODETECT_SIZE_LIMIT option when importing CSVs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -96,6 +96,7 @@ Development
 - Moving assets cdn domain from global.ssl.fastly.net to libs.cartocdn.com [#16399](https://github.com/CartoDB/cartodb/pull/16399)
 - Fix error while rolling back a user migration from one cloud to another [#16421](https://github.com/CartoDB/cartodb/pull/16421)
 - Add retry if a timeout is thrown when swapping the tables related with a sync process [#16430](https://github.com/CartoDB/cartodb/pull/16430)
+- Add AUTODETECT_SIZE_LIMIT to ogr2ogr process when guessing CSV file column types [#16431](https://github.com/CartoDB/cartodb/pull/16431)
 
 4.45.0 (2021-04-14)
 -------------------

--- a/services/importer/lib/importer/ogr2ogr.rb
+++ b/services/importer/lib/importer/ogr2ogr.rb
@@ -180,6 +180,7 @@ module CartoDB
           # Inverse of the selection: if I want guessing I must NOT leave quoted fields as string
           [
             '-oo', 'AUTODETECT_TYPE=YES',
+            '-oo', 'AUTODETECT_SIZE_LIMIT=20000000',
             '-oo', "QUOTED_FIELDS_AS_STRING=#{quoted_fields_guessing ? 'NO' : 'YES'}"
           ] + x_y_possible_names_option + ['-s_srs', 'EPSG:4326', '-t_srs', 'EPSG:4326']
         end


### PR DESCRIPTION
* Related story: https://app.shortcut.com/cartoteam/story/240023/wscc-carto-4-carto-2-import-auto-guessing-significantly-modifying-input-column#activity-248471

Add AUTODETECT_SIZE_LIMIT to perform autoguessing when importing CSV files taking into account the first 20 MB of the file.