### PR TITLE
Log pg_locks when there is a timeout during a sync table importation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,7 @@ Development
 - Fix error while rolling back a user migration from one cloud to another [#16421](https://github.com/CartoDB/cartodb/pull/16421)
 - Add retry if a timeout is thrown when swapping the tables related with a sync process [#16430](https://github.com/CartoDB/cartodb/pull/16430)
 - Add AUTODETECT_SIZE_LIMIT to ogr2ogr process when guessing CSV file column types [#16431](https://github.com/CartoDB/cartodb/pull/16431)
+- Log pg locks if there is any problem during a sync table import process [#16432](https://github.com/CartoDB/cartodb/pull/16432)
 
 4.45.0 (2021-04-14)
 -------------------

--- a/app/models/synchronization/member.rb
+++ b/app/models/synchronization/member.rb
@@ -192,7 +192,7 @@ module CartoDB
 
         database = user.in_database
         overviews_creator = CartoDB::Importer2::Overviews.new(runner, user)
-        importer = CartoDB::Synchronization::Adapter.new(name, runner, database, user, overviews_creator, id)
+        importer = CartoDB::Synchronization::Adapter.new(name, runner, database, user, overviews_creator, id, @log)
 
         importer.run
         self.ran_at   = Time.now


### PR DESCRIPTION
* Check if there is any lock in the table that is going to be replaces during a synchronization process to log the query that is causing the issue